### PR TITLE
Update introduction documentation

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -71,8 +71,6 @@ Using those [node roles](#flow-node-roles), each type of node can be optimized a
 For instance, execution nodes are compute-optimized nodes, leveraging large-scale data centers, while collection nodes are highly bandwidth-optimized.
 Consensus and verification nodes have moderate hardware requirements, allowing for a high degree of participation, requiring only a high-end consumer internet connection.
 
-This architecture lead to a throughput increase by a multiplicative factor of 56.
-
 ### Rules
 
 Flow is based upon the following set of rules:
@@ -116,15 +114,18 @@ Flow differentiates between two sorts of states:
 
 Execution and protocol states are maintained and updated independently. Execution state is maintained and updated by the execution nodes, while the protocol state is maintained and updated by the consensus nodes.
 
-Execution state contains the register values which are modified by the transaction execution. Updates to the execution states are done by the execution nodes but their integrity is governed by the verification process.
+The execution state contains the register values which are modified by the transaction execution. Updates to the execution states are done by the execution nodes but their integrity is governed by the verification process.
 
-Protocol state keeps track of the system related features like staked nodes, node roles, public keys, network addresses and staking amounts. Protocol state is updated when the nodes are slashed, join the system via staking or leave the system by unstaking. Consensus nodes publish updates on the protocol state directly as part of the blocks they generate. Consensus protocol guarantees the integrity of the protocol state.
+The protocol state keeps track of the system related features like staked nodes, node roles, public keys, network addresses and staking amounts.
+It is updated when the nodes are slashed, join the system via staking or leave the system by unstaking.
+Consensus nodes publish updates on the protocol state directly as part of the blocks they generate.
+Consensus protocol guarantees the integrity of the protocol state.
 
 To better illustrate the difference and the independence of the two states, we can consider two scenarios:
 
 **Scenario 1**: Nodes never join, leave or change stake. Transactions are regularly processed. In this system, the protocol state never changes, but the execution state does.
 
-**Scenario 2**: No transactions are submitted/processed. Nodes are regularly joining or leaving the network — here only the network infrastructure / protocol state changes.
+**Scenario 2**: No transactions are submitted/processed. Nodes are regularly joining or leaving the network — here only the network infrastructure/protocol state changes.
 
 ## Flow Node Roles
 
@@ -147,28 +148,30 @@ The clustering mechanism avoids heterogeneous systems where a collection node wi
 Example of a typical sequence for a collection node:
 
 1. Collection node receives a transaction from a user agent
-2. Collection node broadcasts that transaction to the other nodes in its Cluster.
+2. Collection node broadcasts that transaction to the other nodes in its cluster.
 3. Cluster is batching transactions into **collections**.
 4. Collection is submitted to consensus nodes for **inclusion into a block**.
 
-#### Collection formation
+#### Collection Formation
 
 A collection is an ordered list of one or more transactions.
-Collection formation is a process that
-- starts when a user agent submits a transaction to the collection node, and
-- ends when a guaranteed collection is submitted to the consensus nodes
+Collection formation is a process that starts when a user agent submits a transaction to the collection node, and ends when a guaranteed collection is submitted to the consensus nodes.
 
 Cluster nodes continually form consensus on when to start a new collection, the set of transactions to include in the collection under construction, and when to close the current collection and submit it to the consensus nodes.
 As a result of this consensus, a collection grows over time.
 
 Collections are built one at a time — current collection must be closed and submitted to the consensus nodes before a new collection can be started. 
-A collection is closed when the c**ollection size has reached a certain threshold**, or a **predefined time span has passed**.
+A collection is closed when the **collection size has reached a certain threshold**, or a **predefined time span has passed**.
 
-Once a collection has been submitted to the consensus nodes, it becomes a **guaranteed collection**. A guaranteed collection is an immutable data structure. Each node in the cluster that participated in forming the guaranteed collection is called a **guarantor**. Guarantor attests that all transactions in the collection are well formed, and that they will store the entire collection including the full script of all transactions for as long as it is necessary (until execution nodes are done executing them). A guaranteed collection is broadcast by the guarantors to all consensus nodes.
+Once a collection has been submitted to the consensus nodes, it becomes a **guaranteed collection**.
+A guaranteed collection is an immutable data structure.
+Each node in the cluster that participated in forming the guaranteed collection is called a **guarantor**.
+Guarantors attest that all transactions in the collection are well-formed, and that they will store the entire collection including the full script of all transactions for as long as it is necessary (until execution nodes are done executing them).
+A guaranteed collection is broadcast by the guarantors to all consensus nodes.
 
 To vote to append a transaction to a collection, a collection node must verify that:
 1. The collection node has received all the relevant transactions
-2. Transaction is well-formed
+2. The transaction is well-formed
 3. Appending the transaction does not result in duplicate transactions
 4. There are no common transactions between the current collection under construction and any other collection that the cluster of the collection node already guaranteed
 
@@ -191,9 +194,9 @@ It is worth noting that a block in Flow does not include the resulting execution
 
 In order for consensus nodes to seal blocks, they must commit to the execution result of a block after it is executed and verified.
 
-#### Block formation
+#### Block Formation
 
-Block formation is a continuous process executed by the consensus nodes to form new blocks. Block formation has several purposes:
+Block formation is a continuous process performed by the consensus nodes to form new blocks. Block formation has several purposes:
 
 1. Including newly submitted guaranteed collections and reaching aggreement over the order of them
 2. Provide a measure of time by continuously publishing blocks (determining the length of an epoch)
@@ -209,20 +212,20 @@ Block formation is a continuous process executed by the consensus nodes to form 
 
 If there are no guaranteed collections, consensus nodes will continue block formation with an empty set of collections — block formation is never blocked.
 
-Sealing a blocks computation result is done **after** the block itself is finalized.
+Sealing a block's computation result is done **after** the block itself is finalized.
 After the computation results have been broadcast as execution receipts, the consensus nodes wait for the verification in the form of **result approvals** by the verification nodes.
-When a super-majority has approved the result (and no errors were found / slashing results were issued) — execution result is considered for **sealing**.
-**Block seal** is included in the next block that the consensus nodes finalize — block seal for a block is stored in a later block.
+When a super-majority has approved the result (and no errors were found) — execution result is considered for **sealing**.
+A **block seal** is included in the next block that the consensus nodes finalize, meaning that the block seal for a block is stored in a later block.
 
 ### Execution Nodes
 
 The execution nodes determine the results of [transactions](#transactions) when executed in the order determined by the [consensus nodes](#consensus-nodes). 
 They are responsible for scaling the computational power of the blockchain, and are the only node role to have access to the **execution state**.
 Execution nodes follow new blocks as they are published by the consensus nodes.
-Execution process starts when the consensus nodes broadcast evidence that the next block is finalized.
+The execution process starts when the consensus nodes broadcast evidence that the next block is finalized.
 The process ends when the execution nodes broadcast their **execution receipts**.
 
-Conservative execution nodes only process finallized blocks to avoid wasting resources.
+Conservative execution nodes only process finalized blocks to avoid wasting resources.
 An execution node can be optimistic — they are allowed to work on unfinalized blocks.
 This can, however, lead to waste or resources if a block is abandoned later.
 Also, validity of unfinalized blocks is not guaranteed — execution node may be processing an invalid block.
@@ -234,35 +237,35 @@ Execution nodes:
 
 During the execution process the following operations occur:
 - each collection of transactions from the finalized block is retrieved from the relevant cluster
-- execution node executes the transactions according to their cannonical order and update the execution state of the system
-- an execution receipt is built for the block. Execution receipt is a cryptographic commitment on the execution result of the block
-- execution receipt is broadcast to the verification nodes and consensus nodes
+- execution node executes the transactions according to their canonical order and update the execution state of the system
+- an execution receipt is built for the block. An execution receipt is a cryptographic commitment on the execution result of the block
+- the execution receipt is broadcast to the verification nodes and consensus nodes
 
 #### Collection retrieval
 
-Block being executed contains a number of guaranteed collections. Guaranteed collections only includes a hash of the set of transactions, not their full texts.
-Execution node retrieves the collection text from the appropriate cluster, and reconstructs the collection hash from the transaction text to verify the data consistency.
+Blocks being executed contain a number of guaranteed collections. Guaranteed collections only include a hash of the set of transactions, not their full texts.
+Execution nodes retrieve the collection text from the appropriate cluster, and reconstruct the collection hash from the transaction text to verify data consistency.
 Transactions are processed in order.
 
 #### Block Execution
 
-A block is executed when the previous blocks execution result is known.
+A block is executed when the previous block's execution result is known.
 This previous execution result is the starting point for the execution of the block.
 
 Execution receipt for a block includes execution nodes signature, execution result and [SPoCKs](#specialized-proof-of-confidential-knowledge).
-Execution receipt is a signed execution result.
+An execution receipt is a signed execution result.
 The execution receipts can be used to challenge the claims of an execution node when they are shown to be incorrect.
 They are also used to create proofs of the current state of the chain once they are known to be correct.
 
-Execution result of a block includes:
+The execution result of a block includes:
 - block hash
 - hash reference to the previous execution result
 - one or more chunks
 - commitment to the final execution state of the system after executing the block
 
-Execution result has one or more **chunks**.
-**Chunking** is a process of dividing blocks computation into smaller pieces so that individual chunks can be executed and verified in a distributed and parallel manner by many verification nodes.
-Chunks aim to be equally computation-heavy, to avoid a scenario where verification node takes too much time to verify a specific chunk.
+Execution results have one or more **chunks**.
+**Chunking** is a process of dividing a block's computation into smaller pieces so that individual chunks can be executed and verified in a distributed and parallel manner by many verification nodes.
+Chunks aim to be equally computation-heavy, to avoid a scenario where some verification nodes take too long to verify a specific chunk.
 There is a system-wide threshold for chunk computation consumption. 
 Each chunk corresponds to a [collection](#collection-nodes).
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -44,7 +44,8 @@ The final version of the previous execution state remains available through a le
 
 ## Flow
 
-Most current blockchains are built as a homogenous system comprised of *full nodes*. Each full node is expected to collect and choose the transactions to be included in the next block, execute the block, come to a consensus over the output of the block with other full nodes, and finally sign the block and append it to the chain.
+Most current blockchains are built as a homogenous system comprised of *full nodes*.
+Each full node is expected to collect and choose the transactions to be included in the next block, execute the block, come to a consensus over the output of the block with other full nodes, and finally sign the block and append it to the chain.
 
 Existing blockchain architectures have well documented throughput limitations. There are two main approaches to combat this:
 
@@ -53,9 +54,12 @@ Existing blockchain architectures have well documented throughput limitations. T
 
 Layer-2 solutions include include networks like Bitcoin's Lightning and Ethereum's Plasma - these networks work off the main chain.
 
-Sharding represents a technique where a network is broken up into many interconnected networks. Sharding significantly increases the complexity of the programming model by breaking ACID guarantees (Atomicity, Consistency, Isolation and Durability), increasing the cost and time for application development.
+Sharding represents a technique where a network is broken up into many interconnected networks.
+Sharding significantly increases the complexity of the programming model by breaking ACID guarantees (Atomicity, Consistency, Isolation and Durability), increasing the cost and time for application development.
 
-Flow was designed to provide a blockchain that can scale while preserving composability in a single blockchain state. This is achieved by a novel approach where work traditionally assigned to full nodes is split and assigned to specific roles, allowing pipelining. We recognize the following roles in the Flow architecture.
+Flow was designed to provide a blockchain that can scale while preserving composability in a single blockchain state.
+This is achieved by a novel approach where work traditionally assigned to full nodes is split and assigned to specific roles, allowing pipelining.
+We recognize the following roles in the Flow architecture.
 
 1. Collector role - in charge of transaction collection from the user agents
 2. Execution role - in charge of executing the transactions
@@ -63,7 +67,11 @@ Flow was designed to provide a blockchain that can scale while preserving compos
 4. Verification role - done by a more extensive set of Verification Nodes, they confirm that the execution results are correct
 5. Access role - also called Observer role - includes nodes that relay data to protocol-external entities that are not participating in the protocol
 
-By introducing several [node roles](#flow-node-roles), each type of node can be optimized according to the tasks it will perform. For instance, Execution Nodes are compute-optimized nodes, leveraging large-scale data centers, while Collector Nodes are highly bandwidth-optimized. Consensus and Verification Nodes have moderate hardware requirements, allowing for a high degree of participation, requiring only a high-end consumer internet connection.
+By introducing several [node roles](#flow-node-roles), each type of node can be optimized according to the tasks it will perform.
+For instance, Execution Nodes are compute-optimized nodes, leveraging large-scale data centers, while Collector Nodes are highly bandwidth-optimized.
+Consensus and Verification Nodes have moderate hardware requirements, allowing for a high degree of participation, requiring only a high-end consumer internet connection.
+
+This architecture lead to a throughput increase by a multiplicative factor of 56.
 
 ### Rules
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -111,12 +111,12 @@ Flow is designed to guarantee that any error introduced by the execution nodes a
 ### Execution State vs Protocol State
 
 Flow differentiates between two sorts of states:
-1. Execution State (computational state)
-2. Protocol State (network infrastructure state)
+1. Execution state (computational state)
+2. Protocol state (network infrastructure state)
 
-Execution State and Protocol State are maintained and updated independently. Execution state is maintained and updated by the execution nodes, while the Protocol State is maintained and updated by the consensus nodes.
+Execution and protocol states are maintained and updated independently. Execution state is maintained and updated by the execution nodes, while the protocol state is maintained and updated by the consensus nodes.
 
-Execution sState contains the register values which are modified by the transaction execution. Updates to the execution states are done by the execution nodes but their integrity is governed by the verification process.
+Execution state contains the register values which are modified by the transaction execution. Updates to the execution states are done by the execution nodes but their integrity is governed by the verification process.
 
 Protocol state keeps track of the system related features like staked nodes, node roles, public keys, network addresses and staking amounts. Protocol state is updated when the nodes are slashed, join the system via staking or leave the system by unstaking. Consensus nodes publish updates on the protocol state directly as part of the blocks they generate. Consensus protocol guarantees the integrity of the protocol state.
 
@@ -210,8 +210,8 @@ Block formation is a continuous process executed by the consensus nodes to form 
 If there are no guaranteed collections, consensus nodes will continue block formation with an empty set of collections — block formation is never blocked.
 
 Sealing a blocks computation result is done **after** the block itself is finalized.
-After the computation results have been broadcast as Execution Receipts, the consensus nodes wait for the verification in the form of **Result Approvals** by the verification nodes.
-When a super-majority has approved the result (and no errors were found / slashing results were issued) — Execution Result is considered for **sealing**.
+After the computation results have been broadcast as execution receipts, the consensus nodes wait for the verification in the form of **result approvals** by the verification nodes.
+When a super-majority has approved the result (and no errors were found / slashing results were issued) — execution result is considered for **sealing**.
 **Block Seal** is included in the next block that the consensus nodes finalize — block seal for a block is stored in a later block.
 
 ### Execution Nodes
@@ -235,8 +235,8 @@ Execution nodes:
 During the execution process the following operations occur:
 - each collection of transactions from the finalized block is retrieved from the relevant cluster
 - execution node executes the transactions according to their cannonical order and update the execution state of the system
-- an Execution Receipt is built for the block. Execution Receipt is a cryptographic commitment on the execution result of the block
-- Execution Receipt is broadcast to the verification nodes and consensus nodes
+- an execution receipt is built for the block. Execution receipt is a cryptographic commitment on the execution result of the block
+- execution receipt is broadcast to the verification nodes and consensus nodes
 
 #### Collection retrieval
 
@@ -246,15 +246,15 @@ Transactions are processed in order.
 
 #### Block Execution
 
-A block is executed when the previous blocks Execution Result is known.
-This previous Execution Result is the starting point for the execution of the block.
+A block is executed when the previous blocks execution result is known.
+This previous execution result is the starting point for the execution of the block.
 
-Execution Receipt for a block includes execution nodes signature, Excution Result and [SPoCKs](#specialized-proof-of-confidential-knowledge).
-Execution Receipt is a signed Execution Result.
-The Execution Receipts can be used to challenge the claims of an execution node when they are shown to be incorrect.
+Execution receipt for a block includes execution nodes signature, execution result and [SPoCKs](#specialized-proof-of-confidential-knowledge).
+Execution receipt is a signed execution result.
+The execution receipts can be used to challenge the claims of an execution node when they are shown to be incorrect.
 They are also used to create proofs of the current state of the chain once they are known to be correct.
 
-Execution Result of a block includes:
+Execution result of a block includes:
 - block hash
 - hash reference to the previous execution result
 - one or more chunks
@@ -271,12 +271,12 @@ Each chunk corresponds to a [collection](#collector-nodes).
 The verification nodes are in charge of collectively verifying the correctness of the execution nodes' published results.
 With the chunking approach of Flow, each node only checks a small fraction of chunks.
 A verification node requests the information it needs for re-computing the chunks it is checking from the execution nodes.
-It approves the result of a chunk by publishing a **Result Approval** for that chunk.
+It approves the result of a chunk by publishing a **result approval** for that chunk.
 
-When enough Result Approvals have been issued, consensus nodes publish Block Seal as part of the new blocks they finalize.
+When enough result approvals have been issued, consensus nodes publish Block Seal as part of the new blocks they finalize.
 Verification nodes verifiably self-select the chunks they check independently of each other.
-Any Execution Receipt can be checked in isolation.
-If correct, Verifier signs the Execution Result — not the Execution Receipt. Multiple consistent Execution Receipts have identical Execution Results.
+Any execution receipt can be checked in isolation.
+If correct, Verifier signs the execution result — not the execution receipt. Multiple consistent execution receipts have identical execution results.
 
 ### Access Nodes
 
@@ -366,7 +366,7 @@ It is Flows countermeasure so that execution node cannot just copy the result fr
 SPoCKs also make it so that a verification node cannot just blindly approve the execution results of an execution node without actually doing the verification work.
 SPoCKs cannot be copied or forged.
 
-Execution Result has a list of SPoCKs — each SPoCK coresponds to a chunk, and a SPoCK for a chunk can only be generated by executing the chunk.
+Execution result has a list of SPoCKs — each SPoCK coresponds to a chunk, and a SPoCK for a chunk can only be generated by executing the chunk.
 
 This secret is derived from the execution trace — the cheapest way one can get the execution trace is by executing the entire computation.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -214,6 +214,11 @@ Execution nodes follow new blocks as they are published by the Consensus Nodes.
 Execution process starts when the Consensus Nodes broadcast evidence that the next block is finalized.
 The process ends when the Execution Nodes broadcast their **execution receipts**.
 
+Conservative Execution Nodes only process finallized blocks to avoid wasting resources.
+An Execution Node can be optimistic - they are allowed to work on unfinalized blocks.
+This can, however, lead to waste or resources if a block is abandoned later.
+Also, validity of unfinalized blocks is not guaranteed - Execution Node may be processing an invalid block.
+
 Execution nodes:
 - receive a finalized block
 - execute the transactions

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,30 +5,36 @@ This document is aimed at introducing developers to the Flow Data Provisioning S
 **Table of Contents**
 
 1. [Getting Started](#getting-started)
-2. [Flow overview](#flow)
-    1. [Rules](#rules)
-    2. [Errors](#errors)
-    3. [Execution state vs Protocol state](#execution-state-vs-protocol-state)
-3. [Flow Node roles](#flow-node-roles)
-    * [Collection Nodes](#collection-nodes)
-    * [Consensus Nodes](#consensus-nodes)
-    * [Execution Nodes](#execution-nodes)
-    * [Verification Nodes](#verification-nodes)
-    * [Access Nodes](#access-nodes)
+2. [Flow](#flow)
+   1. [Rules](#rules)
+   2. [Errors](#errors)
+   3. [Execution State vs Protocol State](#execution-state-vs-protocol-state)
+3. [Flow Node Roles](#flow-node-roles)
+   1. [Collection Nodes](#collection-nodes)
+      1. [Collection Formation](#collection-formation)
+   2. [Consensus Nodes](#consensus-nodes)
+      1. [Block Formation](#block-formation)
+   3. [Execution Nodes](#execution-nodes)
+      1. [Collection retrieval](#collection-retrieval)
+      2. [Block Execution](#block-execution)
+   4. [Verification Nodes](#verification-nodes)
+   5. [Access Nodes](#access-nodes)
 4. [Glossary](#glossary)
-    1. [Proof of Stake](#proof-of-stake)
-    2. [Staking](#staking)
-    3. [Slashing](#slashing)
-    4. [Sporks](#sporks)
-    5. [Cadence](#cadence)
-    6. [Transactions](#transactions)
-    7. [Byzantine Fault](#byzantine-fault)
-    8. [Merkle Patricia Tries](#merkle-patricia-tries)
-    9. [Specialized Proof of Confidential Knowledge](#specialized-proof-of-confidential-knowledge)
+   1. [Proof of Stake](#proof-of-stake)
+   2. [Staking](#staking)
+   3. [Slashing](#slashing)
+   4. [Sporks](#sporks)
+   5. [Cadence](#cadence)
+   6. [Transactions](#transactions)
+   7. [Byzantine Fault](#byzantine-fault)
+   8. [Merkle Patricia Tries](#merkle-patricia-tries)
+   9. [Specialized Proof of Confidential Knowledge](#specialized-proof-of-confidential-knowledge)
 5. [Developer Guide](#developer-guide)
-    1. [Installation](#installation)
-    2. [Setting up a test environment](#setting-up-a-test-environment)
-6. [More resources](#more-resources)
+   1. [Installation](#installation)
+      1. [Dependencies](#dependencies)
+      2. [Manual Build](#manual-build)
+   2. [Setting up a test environment](#setting-up-a-test-environment)
+6. [More Resources](#more-resources)
 
 ## Getting Started
 
@@ -45,9 +51,12 @@ The final version of the previous execution state remains available through a le
 ## Flow
 
 Most current blockchains are built as a homogenous system comprised of *full nodes*.
-Each full node is expected to collect and choose the transactions to be included in the next block, execute the block, come to a consensus over the output of the block with other full nodes, and finally sign the block and append it to the chain.
+Every full node collects and propagates the transaction it sees on the network.
+When being able to mine the next block, or being selected as the leader to propose the next block, they will choose the transactions to include according to the consensus rules.
+This means that every node needs to be able to execute every transaction it includes in a block in order to validate them.
+When validating other nodes' blocks, every node also needs to run every transaction to validate the block's correctness.
 
-Existing blockchain architectures have well documented throughput limitations. Two approaches to mitigate this are layer-2 networks and sharding.
+These existing blockchain architectures thus suffer from well documented throughput limitations. Two approaches to mitigate this are layer-2 networks and sharding.
 
 Layer-2 solutions include include networks like Bitcoin's Lightning and Ethereum's Plasma — these networks work off the main chain.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -54,7 +54,7 @@ Existing blockchain architectures have well documented throughput limitations. T
 
 Layer-2 solutions include include networks like Bitcoin's Lightning and Ethereum's Plasma — these networks work off the main chain.
 
-Sharding represents a technique where a network is broken up into many interconnected networks.
+Sharding is a technique where a network is broken up into many interconnected networks.
 Sharding significantly increases the complexity of the programming model by breaking ACID guarantees (Atomicity, Consistency, Isolation and Durability), increasing the cost and time for application development.
 
 Flow was designed to provide a blockchain that can scale while preserving composability in a single blockchain state.
@@ -64,12 +64,12 @@ We recognize the following roles in the Flow architecture.
 1. Collector role — in charge of transaction collection from the user agents
 2. Execution role — in charge of executing the transactions
 3. Consensus role — maintain the chain of blocks and responsible for the chain extension by appending new blocks. These nodes also rule on reported misbehaviors of other nodes
-4. Verification role — done by a more extensive set of Verification Nodes, they confirm that the execution results are correct
+4. Verification role — done by a more extensive set of verification nodes, they confirm that the execution results are correct
 5. Access role — also called Observer role — includes nodes that relay data to protocol-external entities that are not participating in the protocol
 
-By introducing several [node roles](#flow-node-roles), each type of node can be optimized according to the tasks it will perform.
-For instance, Execution Nodes are compute-optimized nodes, leveraging large-scale data centers, while Collector Nodes are highly bandwidth-optimized.
-Consensus and Verification Nodes have moderate hardware requirements, allowing for a high degree of participation, requiring only a high-end consumer internet connection.
+Using those [node roles](#flow-node-roles), each type of node can be optimized according to the tasks it performs.
+For instance, execution nodes are compute-optimized nodes, leveraging large-scale data centers, while collector nodes are highly bandwidth-optimized.
+Consensus and verification nodes have moderate hardware requirements, allowing for a high degree of participation, requiring only a high-end consumer internet connection.
 
 This architecture lead to a throughput increase by a multiplicative factor of 56.
 
@@ -101,7 +101,7 @@ Flow is based upon the following set of rules:
 
 ### Errors
 
-Flow is designed to guarantee that any error introduced by the Execution Nodes are always guaranteed to have four critical attributes:
+Flow is designed to guarantee that any error introduced by the execution nodes are always guaranteed to have four critical attributes:
 
 * **Detectable**: A deterministic process has an objectively correct output. Therefore, even a single honest node in the network can detect deterministic faults and prove the error to all other honest nodes by pointing out the part of the process that was executed incorrectly.
 * **Attributable**: The output of all deterministic processes in Flow but be signed with the identity of the node that generated those results. As such, any error that has been detected can be clearly attributed to the node(s) that were responsible for that process.
@@ -114,11 +114,11 @@ Flow differentiates between two sorts of states:
 1. Execution State (computational state)
 2. Protocol State (network infrastructure state)
 
-Execution State and Protocol State are maintained and updated independently. Execution state is maintained and updated by the Execution Nodes, while the Protocol State is maintained and updated by the Consensus Nodes.
+Execution State and Protocol State are maintained and updated independently. Execution state is maintained and updated by the execution nodes, while the Protocol State is maintained and updated by the consensus nodes.
 
-Execution sState contains the register values which are modified by the transaction execution. Updates to the execution states are done by the Execution Nodes but their integrity is governed by the verification process.
+Execution sState contains the register values which are modified by the transaction execution. Updates to the execution states are done by the execution nodes but their integrity is governed by the verification process.
 
-Protocol state keeps track of the system related features like staked nodes, node roles, public keys, network addresses and staking amounts. Protocol state is updated when the nodes are slashed, join the system via staking or leave the system by unstaking. Consensus Nodes publish updates on the protocol state directly as part of the blocks they generate. Consensus protocol guarantees the integrity of the protocol state.
+Protocol state keeps track of the system related features like staked nodes, node roles, public keys, network addresses and staking amounts. Protocol state is updated when the nodes are slashed, join the system via staking or leave the system by unstaking. Consensus nodes publish updates on the protocol state directly as part of the blocks they generate. Consensus protocol guarantees the integrity of the protocol state.
 
 To better illustrate the difference and the independence of the two states, we can consider two scenarios:
 
@@ -132,51 +132,51 @@ To better illustrate the difference and the independence of the two states, we c
 
 ### Collector Nodes
 
-Collector Nodes are nodes in charge of collecting transactions from user agents.
+Collector nodes are nodes in charge of collecting transactions from user agents.
 For the sake of load-balancing, redundancy and [Byzantine resilience](#byzantine-fault), they are all [staked](#staking) equally and randomly partitioned into clusters of roughly equal size (sizes of each two different clusters varies by at most a single node).
 Cluster sizes are hinted to be in the range of 20-80 nodes in a mature system.
 
-At the beginning of an epoch, each Collector Node is randomly assigned to exactly one cluster.
+At the beginning of an epoch, each collector node is randomly assigned to exactly one cluster.
 Number of clusters is a protocol parameter.
 
 Each cluster of collection nodes acts as a gateway to Flow from the external world.
 There is a **one-way deterministic assignment** between each transaction and a cluster that is responsible for processing it.
-When a Collector Node receives a transaction, it also checks whether it was submitted to the correct cluster.
-The clustering mechanism avoids heterogeneous systems where a Collector Node with better service would be getting all the traffic and end up reducing the decentralization of the whole system as well as starving out other Collector Nodes.
+When a collector node receives a transaction, it also checks whether it was submitted to the correct cluster.
+The clustering mechanism avoids heterogeneous systems where a collector node with better service would be getting all the traffic and end up reducing the decentralization of the whole system as well as starving out other collector nodes.
 
-Example of a typical sequence for a Collector Node:
+Example of a typical sequence for a collector node:
 
-1. Collector Node receives a transaction from a user agent
-2. Collector Node broadcasts that transaction to the other nodes in its Cluster.
+1. Collector node receives a transaction from a user agent
+2. Collector node broadcasts that transaction to the other nodes in its Cluster.
 3. Cluster is batching transactions into **collections**.
-4. Collection is submitted to Consensus Nodes for **inclusion into a block**.
+4. Collection is submitted to consensus nodes for **inclusion into a block**.
 
 #### Collection formation
 
 A collection is an ordered list of one or more transactions.
 Collection formation is a process that
-- starts when a user agent submits a transaction to the Collector Node, and
-- ends when a guaranteed collection is submitted to the Consensus Nodes
+- starts when a user agent submits a transaction to the collector node, and
+- ends when a guaranteed collection is submitted to the consensus nodes
 
-Cluster nodes continually form consensus on when to start a new collection, the set of transactions to include in the collection under construction, and when to close the current collection and submit it to the Consensus Nodes.
+Cluster nodes continually form consensus on when to start a new collection, the set of transactions to include in the collection under construction, and when to close the current collection and submit it to the consensus nodes.
 As a result of this consensus, a collection grows over time.
 
-Collections are built one at a time — current collection must be closed and submitted to the Consensus Nodes before a new collection can be started. 
+Collections are built one at a time — current collection must be closed and submitted to the consensus nodes before a new collection can be started. 
 A Collection is closed when the c**ollection size has reached a certain threshold**, or a **predefined time span has passed**.
 
-Once a collection has been submitted to the Consensus Nodes, it becomes a **guaranteed collection**. A guaranteed collection is an immutable data structure. Each node in the cluster that participated in forming the guaranteed collection is called a **guarantor**. Guarantor attests that all transactions in the collection are well formed, and that they will store the entire collection including the full script of all transactions for as long as it is necessary (until Execution Nodes are done executing them). A guaranteed collection is broadcast by the guarantors to all Consensus Nodes.
+Once a collection has been submitted to the consensus nodes, it becomes a **guaranteed collection**. A guaranteed collection is an immutable data structure. Each node in the cluster that participated in forming the guaranteed collection is called a **guarantor**. Guarantor attests that all transactions in the collection are well formed, and that they will store the entire collection including the full script of all transactions for as long as it is necessary (until execution nodes are done executing them). A guaranteed collection is broadcast by the guarantors to all consensus nodes.
 
-To vote to append a transaction to a collection, a Collector Node must verify that:
-1. The Collector Node has received all the relevant transactions
+To vote to append a transaction to a collection, a collector node must verify that:
+1. The collector node has received all the relevant transactions
 2. Transaction is well-formed
 3. Appending the transaction does not result in duplicate transactions
-4. There are no common transactions between the current collection under construction and any other collection that the cluster of the Collector Node already guaranteed
+4. There are no common transactions between the current collection under construction and any other collection that the cluster of the collector node already guaranteed
 
-Collector Node must store all the transactions of all guaranteed collections, and must produce relevant transaction when requested by the Execution Nodes. If they fail to do so, they will be slashed, along with the rest of the cluster.
+Collector node must store all the transactions of all guaranteed collections, and must produce relevant transaction when requested by the execution nodes. If they fail to do so, they will be slashed, along with the rest of the cluster.
 
 ### Consensus Nodes
 
-The consensus nodes work with transaction batches - [_collections_](#collector-nodes), submitted by the Collector Nodes.
+The consensus nodes work with transaction batches - [_collections_](#collector-nodes), submitted by the collector nodes.
 They form blocks from collections, are in charge of sealing those blocks, and adjudicate slashing requests from other nodes (for example, claims that an execution node has produced incorrect outputs.)
 
 Since the responsibility to maintain a large state is delegated to specialized nodes, hardware requirements for consensus nodes remain moderate even for high-throughput blockchains.
@@ -193,39 +193,39 @@ In order for consensus nodes to seal blocks, they must commit to the execution r
 
 #### Block formation
 
-Block formation is a continuous process executed by the Consensus Nodes to form new blocks. Block formation has several purposes:
+Block formation is a continuous process executed by the consensus nodes to form new blocks. Block formation has several purposes:
 
 1. Including newly submitted guaranteed collections and reaching aggreement over the order of them
 2. Provide a measure of time by continuously publishing blocks (determining the length of an epoch)
 3. Publish block seals for previous blocks of the chain. The block is ready to be sealed when
-    1. It has been finalized by the Consensus Nodes
-    2. It has been executed by the Execution Nodes
-    3. The execution results are approved by the Verification Nodes
+    1. It has been finalized by the consensus nodes
+    2. It has been executed by the execution nodes
+    3. The execution results are approved by the verification nodes
 4. Publishing slashing challenges and respective adjudications results (rulings)
 5. Publishing protocol state updates
     - staking, unstaking and slashing
-    - whenever a nodes stake changes, Consensus Nodes include that update in the next block
+    - whenever a nodes stake changes, consensus nodes include that update in the next block
 6. Providing a state of randomness
 
-If there are no guaranteed collections, Consensus Nodes will continue block formation with an empty set of collections — block formation is never blocked.
+If there are no guaranteed collections, consensus nodes will continue block formation with an empty set of collections — block formation is never blocked.
 
 Sealing a blocks computation result is done **after** the block itself is finalized.
-After the computation results have been broadcast as Execution Receipts, the Consensus Nodes wait for the verification in the form of **Result Approvals** by the Verification Nodes.
+After the computation results have been broadcast as Execution Receipts, the consensus nodes wait for the verification in the form of **Result Approvals** by the verification nodes.
 When a super-majority has approved the result (and no errors were found / slashing results were issued) — Execution Result is considered for **sealing**.
-**Block Seal** is included in the next block that the Consensus Nodes finalize — block seal for a block is stored in a later block.
+**Block Seal** is included in the next block that the consensus nodes finalize — block seal for a block is stored in a later block.
 
 ### Execution Nodes
 
-The Execution Nodes determine the results of [transactions](#transactions) when executed in the order determined by the [consensus nodes](#consensus-nodes). 
+The execution nodes determine the results of [transactions](#transactions) when executed in the order determined by the [consensus nodes](#consensus-nodes). 
 They are responsible for scaling the computational power of the blockchain, and are the only node role to have access to the **execution state**.
-Execution nodes follow new blocks as they are published by the Consensus Nodes.
-Execution process starts when the Consensus Nodes broadcast evidence that the next block is finalized.
-The process ends when the Execution Nodes broadcast their **execution receipts**.
+Execution nodes follow new blocks as they are published by the consensus nodes.
+Execution process starts when the consensus nodes broadcast evidence that the next block is finalized.
+The process ends when the execution nodes broadcast their **execution receipts**.
 
-Conservative Execution Nodes only process finallized blocks to avoid wasting resources.
-An Execution Node can be optimistic — they are allowed to work on unfinalized blocks.
+Conservative execution nodes only process finallized blocks to avoid wasting resources.
+An execution node can be optimistic — they are allowed to work on unfinalized blocks.
 This can, however, lead to waste or resources if a block is abandoned later.
-Also, validity of unfinalized blocks is not guaranteed — Execution Node may be processing an invalid block.
+Also, validity of unfinalized blocks is not guaranteed — execution node may be processing an invalid block.
 
 Execution nodes:
 - receive a finalized block
@@ -234,14 +234,14 @@ Execution nodes:
 
 During the execution process the following operations occur:
 - each collection of transactions from the finalized block is retrieved from the relevant cluster
-- Execution Node executes the transactions according to their cannonical order and update the execution state of the system
+- execution node executes the transactions according to their cannonical order and update the execution state of the system
 - an Execution Receipt is built for the block. Execution Receipt is a cryptographic commitment on the execution result of the block
-- Execution Receipt is broadcast to the Verification Nodes and Consensus Nodes
+- Execution Receipt is broadcast to the verification nodes and consensus nodes
 
 #### Collection retrieval
 
 Block being executed contains a number of guaranteed collections. Guaranteed collections only includes a hash of the set of transactions, not their full texts.
-Execution Node retrieves the collection text from the appropriate cluster, and reconstructs the collection hash from the transaction text to verify the data consistency.
+Execution node retrieves the collection text from the appropriate cluster, and reconstructs the collection hash from the transaction text to verify the data consistency.
 Transactions are processed in order.
 
 #### Block Execution
@@ -249,7 +249,7 @@ Transactions are processed in order.
 A block is executed when the previous blocks Execution Result is known.
 This previous Execution Result is the starting point for the execution of the block.
 
-Execution Receipt for a block includes Execution Nodes signature, Excution Result and [SPoCKs](#specialized-proof-of-confidential-knowledge).
+Execution Receipt for a block includes execution nodes signature, Excution Result and [SPoCKs](#specialized-proof-of-confidential-knowledge).
 Execution Receipt is a signed Execution Result.
 The Execution Receipts can be used to challenge the claims of an execution node when they are shown to be incorrect.
 They are also used to create proofs of the current state of the chain once they are known to be correct.
@@ -262,7 +262,7 @@ Execution Result of a block includes:
 
 Execution result has one or more **chunks**.
 **Chunking** is a process of dividing blocks computation into smaller pieces so that individual chunks can be executed and verified in a distributed and parallel manner by many verification nodes.
-Chunks aim to be equally computation-heavy, to avoid a scenario where Verification Node takes too much time to verify a specific chunk.
+Chunks aim to be equally computation-heavy, to avoid a scenario where verification node takes too much time to verify a specific chunk.
 There is a system wide threshold for chunk computation consumption. 
 Each chunk corresponds to a [collection](#collector-nodes).
 
@@ -273,8 +273,8 @@ With the chunking approach of Flow, each node only checks a small fraction of ch
 A verification node requests the information it needs for re-computing the chunks it is checking from the execution nodes.
 It approves the result of a chunk by publishing a **Result Approval** for that chunk.
 
-When enough Result Approvals have been issued, Consensus Nodes publish Block Seal as part of the new blocks they finalize.
-Verification Nodes verifiably self-select the chunks they check independently of each other.
+When enough Result Approvals have been issued, consensus nodes publish Block Seal as part of the new blocks they finalize.
+Verification nodes verifiably self-select the chunks they check independently of each other.
 Any Execution Receipt can be checked in isolation.
 If correct, Verifier signs the Execution Result — not the Execution Receipt. Multiple consistent Execution Receipts have identical Execution Results.
 
@@ -362,8 +362,8 @@ The Flow implementation of radix trees introduces a number of improvements:
 ### Specialized Proof of Confidential Knowledge
 
 Specialized Proof of Confidential Knowledge or SPoCK allows provers to demonstrate that they have some confidential knowledge (secret) without leaking any information about the secret.
-It is Flows countermeasure so that Execution Node cannot just copy the result from another Execution Node.
-SPoCKs also make it so that a Verification Node cannot just blindly approve the execution results of an Execution Node without actually doing the verification work.
+It is Flows countermeasure so that execution node cannot just copy the result from another execution node.
+SPoCKs also make it so that a verification node cannot just blindly approve the execution results of an execution node without actually doing the verification work.
 SPoCKs cannot be copied or forged.
 
 Execution Result has a list of SPoCKs — each SPoCK coresponds to a chunk, and a SPoCK for a chunk can only be generated by executing the chunk.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -52,7 +52,7 @@ Existing blockchain architectures have well documented throughput limitations. T
 1. Layer-2 networks
 2. Sharding
 
-Layer-2 solutions include include networks like Bitcoin's Lightning and Ethereum's Plasma - these networks work off the main chain.
+Layer-2 solutions include include networks like Bitcoin's Lightning and Ethereum's Plasma — these networks work off the main chain.
 
 Sharding represents a technique where a network is broken up into many interconnected networks.
 Sharding significantly increases the complexity of the programming model by breaking ACID guarantees (Atomicity, Consistency, Isolation and Durability), increasing the cost and time for application development.
@@ -61,11 +61,11 @@ Flow was designed to provide a blockchain that can scale while preserving compos
 This is achieved by a novel approach where work traditionally assigned to full nodes is split and assigned to specific roles, allowing pipelining.
 We recognize the following roles in the Flow architecture.
 
-1. Collector role - in charge of transaction collection from the user agents
-2. Execution role - in charge of executing the transactions
-3. Consensus role - maintain the chain of blocks and responsible for the chain extension by appending new blocks. These nodes also rule on reported misbehaviors of other nodes
-4. Verification role - done by a more extensive set of Verification Nodes, they confirm that the execution results are correct
-5. Access role - also called Observer role - includes nodes that relay data to protocol-external entities that are not participating in the protocol
+1. Collector role — in charge of transaction collection from the user agents
+2. Execution role — in charge of executing the transactions
+3. Consensus role — maintain the chain of blocks and responsible for the chain extension by appending new blocks. These nodes also rule on reported misbehaviors of other nodes
+4. Verification role — done by a more extensive set of Verification Nodes, they confirm that the execution results are correct
+5. Access role — also called Observer role — includes nodes that relay data to protocol-external entities that are not participating in the protocol
 
 By introducing several [node roles](#flow-node-roles), each type of node can be optimized according to the tasks it will perform.
 For instance, Execution Nodes are compute-optimized nodes, leveraging large-scale data centers, while Collector Nodes are highly bandwidth-optimized.
@@ -124,7 +124,7 @@ To better illustrate the difference and the independence of the two states, we c
 
 **Scenario 1**: Nodes never join, leave or change stake. Transactions are regularly processed. In this system, the protocol state never changes, but the execution state does.
 
-**Scenario 2**: No transactions are submitted/processed. Nodes are regularly joining or leaving the network - here only the network infrastructure / protocol state changes.
+**Scenario 2**: No transactions are submitted/processed. Nodes are regularly joining or leaving the network — here only the network infrastructure / protocol state changes.
 
 ## Flow Node Roles
 
@@ -161,7 +161,7 @@ Collection formation is a process that
 Cluster nodes continually form consensus on when to start a new collection, the set of transactions to include in the collection under construction, and when to close the current collection and submit it to the Consensus Nodes.
 As a result of this consensus, a collection grows over time.
 
-Collections are built one at a time - current collection must be closed and submitted to the Consensus Nodes before a new collection can be started. 
+Collections are built one at a time — current collection must be closed and submitted to the Consensus Nodes before a new collection can be started. 
 A Collection is closed when the c**ollection size has reached a certain threshold**, or a **predefined time span has passed**.
 
 Once a collection has been submitted to the Consensus Nodes, it becomes a **guaranteed collection**. A guaranteed collection is an immutable data structure. Each node in the cluster that participated in forming the guaranteed collection is called a **guarantor**. Guarantor attests that all transactions in the collection are well formed, and that they will store the entire collection including the full script of all transactions for as long as it is necessary (until Execution Nodes are done executing them). A guaranteed collection is broadcast by the guarantors to all Consensus Nodes.
@@ -207,12 +207,12 @@ Block formation is a continuous process executed by the Consensus Nodes to form 
     - whenever a nodes stake changes, Consensus Nodes include that update in the next block
 6. Providing a state of randomness
 
-If there are no guaranteed collections, Consensus Nodes will continue block formation with an empty set of collections - block formation is never blocked.
+If there are no guaranteed collections, Consensus Nodes will continue block formation with an empty set of collections — block formation is never blocked.
 
 Sealing a blocks computation result is done **after** the block itself is finalized.
 After the computation results have been broadcast as Execution Receipts, the Consensus Nodes wait for the verification in the form of **Result Approvals** by the Verification Nodes.
-When a super-majority has approved the result (and no errors were found / slashing results were issued) - Execution Result is considered for **sealing**.
-**Block Seal** is included in the next block that the Consensus Nodes finalize - block seal for a block is stored in a later block.
+When a super-majority has approved the result (and no errors were found / slashing results were issued) — Execution Result is considered for **sealing**.
+**Block Seal** is included in the next block that the Consensus Nodes finalize — block seal for a block is stored in a later block.
 
 ### Execution Nodes
 
@@ -223,9 +223,9 @@ Execution process starts when the Consensus Nodes broadcast evidence that the ne
 The process ends when the Execution Nodes broadcast their **execution receipts**.
 
 Conservative Execution Nodes only process finallized blocks to avoid wasting resources.
-An Execution Node can be optimistic - they are allowed to work on unfinalized blocks.
+An Execution Node can be optimistic — they are allowed to work on unfinalized blocks.
 This can, however, lead to waste or resources if a block is abandoned later.
-Also, validity of unfinalized blocks is not guaranteed - Execution Node may be processing an invalid block.
+Also, validity of unfinalized blocks is not guaranteed — Execution Node may be processing an invalid block.
 
 Execution nodes:
 - receive a finalized block
@@ -276,7 +276,7 @@ It approves the result of a chunk by publishing a **Result Approval** for that c
 When enough Result Approvals have been issued, Consensus Nodes publish Block Seal as part of the new blocks they finalize.
 Verification Nodes verifiably self-select the chunks they check independently of each other.
 Any Execution Receipt can be checked in isolation.
-If correct, Verifier signs the Execution Result - not the Execution Receipt. Multiple consistent Execution Receipts have identical Execution Results.
+If correct, Verifier signs the Execution Result — not the Execution Receipt. Multiple consistent Execution Receipts have identical Execution Results.
 
 ### Access Nodes
 
@@ -366,9 +366,9 @@ It is Flows countermeasure so that Execution Node cannot just copy the result fr
 SPoCKs also make it so that a Verification Node cannot just blindly approve the execution results of an Execution Node without actually doing the verification work.
 SPoCKs cannot be copied or forged.
 
-Execution Result has a list of SPoCKs - each SPoCK coresponds to a chunk, and a SPoCK for a chunk can only be generated by executing the chunk.
+Execution Result has a list of SPoCKs — each SPoCK coresponds to a chunk, and a SPoCK for a chunk can only be generated by executing the chunk.
 
-This secret is derived from the execution trace - the cheapest way one can get the execution trace is by executing the entire computation.
+This secret is derived from the execution trace — the cheapest way one can get the execution trace is by executing the entire computation.
 
 ## Developer Guide
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -279,7 +279,7 @@ The execution result of a block includes:
 
 Execution results have one or more **chunks**.
 **Chunking** is a process of dividing a block's computation into smaller pieces so that individual chunks can be executed and verified in a distributed and parallel manner by many verification nodes.
-Chunks aim to be equally computation-heavy, to avoid a scenario where some verification nodes take too long to verify a specific chunk.
+Chunks should have approximately equal needs in terms of computation resources, to avoid a scenario where some verification nodes take too long to verify a specific chunk.
 There is a system-wide threshold for chunk computation consumption. 
 Each chunk corresponds to a [collection](#collection-nodes).
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -419,4 +419,4 @@ You can then run the DPS, and it should properly build its index based on the gi
 * [Flow Technical Papers](https://www.onflow.org/technical-paper)
 * [Flow Developer Documentation](https://docs.onflow.org/)
 * [Flow Developer Discord Server](https://onflow.org/discord)
-* [Scalability Trilemma](https://aakash-111.medium.com/the-scalability-trilemma-in-blockchain-75fb57f646df)
+* [Scalability Trilemma](https://vitalik.ca/general/2021/04/07/sharding.html)


### PR DESCRIPTION
This PR updates / expand the introduction document.

- expanded the information about specific node roles
- added information about how certain processes work (cluster formation, collection formation, block formation etc)
- restructured the node sections to better reflect the order of actions ocurring in the system
- split the section describing the Flow blockchain to two sections - overview and node roles/actions. I'm not too happy with it, but the previous approach would lead to too much nesting (e.g. Root => What is Flow => [Glossary => ] Nodes => Consensus Nodes => Block Formation) and the headers stop making sense for the smaller sections. perhaps it should even be in a separate document
- glossary was moved to a separate section, though it probably makes more sense to move back under the `Flow Overview` section

I tried to only remove only information is is described in more detail further down the line, and to keep up with the one-sentence-per-line style.

I feel it would be good to review both the correctness of the content and the structure itself.