### PR TITLE
Add REST API unit tests

### DIFF
--- a/api/rest/controller.go
+++ b/api/rest/controller.go
@@ -33,11 +33,11 @@ type Controller struct {
 	state dps.State
 }
 
-func NewController(state dps.State) (*Controller, error) {
+func NewController(state dps.State) *Controller {
 	c := &Controller{
 		state: state,
 	}
-	return c, nil
+	return c
 }
 
 // TODO: integration testing of GetRegister endpoint

--- a/api/rest/controller_test.go
+++ b/api/rest/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/dgraph-io/badger/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,7 +112,7 @@ func TestController_GetRegister(t *testing.T) {
 			lastHeight: lastHeight,
 
 			stateGet: func(bytes []byte) ([]byte, error) {
-				return nil, dps.ErrNotFound
+				return nil, badger.ErrKeyNotFound
 			},
 
 			wantStatus: http.StatusNotFound,
@@ -288,7 +289,7 @@ func TestController_GetValue(t *testing.T) {
 			keys: validKeys,
 
 			stateGet: func(query *ledger.Query) ([]ledger.Value, error) {
-				return nil, dps.ErrNotFound
+				return nil, badger.ErrKeyNotFound
 			},
 
 			wantStatus: http.StatusNotFound,

--- a/api/rest/controller_test.go
+++ b/api/rest/controller_test.go
@@ -37,9 +37,9 @@ import (
 
 func TestController_GetRegister(t *testing.T) {
 	const (
-		keyHex   = "746573744b6579"
-		value    = "testValue"
-		valueHex = "7465737456616c7565"
+		keyHex     = "746573744b6579"
+		value      = "testValue"
+		valueHex   = "7465737456616c7565"
 		lastHeight = 835
 	)
 

--- a/api/rest/controller_test.go
+++ b/api/rest/controller_test.go
@@ -202,12 +202,13 @@ func TestController_GetValue(t *testing.T) {
 	const (
 		validKeys         = "0.,1.,2.746573744b6579:0.,1.,2.746573744b657932"
 		invalidKeys       = "non-hexadecimal value"
-		lastCommit        = "f61d098cfd435e79a43c574a8512275f"
-		lastCommitHex     = "6636316430393863666434333565373961343363353734613835313232373566"
+		lastCommitHex     = "0102030405060708090a0102030405060708090a0102030405060708090a0102"
 		customCommitParam = "3732396638393566663833126661376434313137623730333731346338623337"
 		value             = "testValue"
 		valueHex          = "7465737456616c7565"
 	)
+
+	var lastCommit = flow.StateCommitment{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2}
 
 	tests := []struct {
 		desc string

--- a/api/rest/encoding_test.go
+++ b/api/rest/encoding_test.go
@@ -114,6 +114,21 @@ func TestDecodeKey(t *testing.T) {
 			want:    state.RegisterIDToKey(flow.NewRegisterID("", "", "testKey")),
 			wantErr: assert.NoError,
 		},
+		"invalid key parts": {
+			key: "invalid key",
+
+			wantErr: assert.Error,
+		},
+		"invalid key part type": {
+			key: "invalid.invalid,invalid.invalid,invalid.invalid",
+
+			wantErr: assert.Error,
+		},
+		"invalid key part value": {
+			key: "0.invalid,1.invalid,2.invalid",
+
+			wantErr: assert.Error,
+		},
 		"empty key": {
 			key: "",
 
@@ -155,6 +170,21 @@ func TestDecodeKeys(t *testing.T) {
 				state.RegisterIDToKey(flow.NewRegisterID("", "", "testKey2")),
 			},
 			wantErr: assert.NoError,
+		},
+		"invalid key parts": {
+			keys: "invalid key:invalid key",
+
+			wantErr: assert.Error,
+		},
+		"invalid key part type": {
+			keys: "invalid.invalid,invalid.invalid,invalid.invalid:invalid.invalid,invalid.invalid,invalid.invalid",
+
+			wantErr: assert.Error,
+		},
+		"invalid key part value": {
+			keys: "0.invalid,1.invalid,2.invalid:0.invalid,1.invalid,2.invalid",
+
+			wantErr: assert.Error,
 		},
 		"empty keys": {
 			keys:    ":",

--- a/api/rest/encoding_test.go
+++ b/api/rest/encoding_test.go
@@ -1,0 +1,131 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package rest_test
+
+import (
+	"testing"
+
+	exec "github.com/onflow/flow-go/engine/execution/state"
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/optakt/flow-dps/api/rest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeKey(t *testing.T) {
+	tests := map[string]struct {
+		key  ledger.Key
+		want string
+	}{
+		"nominal case": {
+			key:  exec.RegisterIDToKey(flow.NewRegisterID("testOwner", "testController", "testKey")),
+			want: "0.746573744f776e6572,1.74657374436f6e74726f6c6c6572,2.746573744b6579",
+		},
+		"empty key parts": {
+			key:  exec.RegisterIDToKey(flow.NewRegisterID("", "", "testKey")),
+			want: "0.,1.,2.746573744b6579",
+		},
+		"empty key": {
+			key:  ledger.Key{},
+			want: "",
+		},
+	}
+
+	for desc, test := range tests {
+		test := test
+		t.Run(desc, func(t *testing.T) {
+			t.Parallel()
+			got := rest.EncodeKey(test.key)
+
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestEncodeKeys(t *testing.T) {
+	tests := map[string]struct {
+		keys  []ledger.Key
+		want string
+	}{
+		"nominal case": {
+			keys:  []ledger.Key{
+				exec.RegisterIDToKey(flow.NewRegisterID("testOwner", "testController", "testKey")),
+				exec.RegisterIDToKey(flow.NewRegisterID("testOwner2", "testController2", "testKey2")),
+			},
+			want: "0.746573744f776e6572,1.74657374436f6e74726f6c6c6572,2.746573744b6579:0.746573744f776e657232,1.74657374436f6e74726f6c6c657232,2.746573744b657932",
+		},
+		"empty key parts": {
+			keys:  []ledger.Key{
+				exec.RegisterIDToKey(flow.NewRegisterID("", "", "testKey")),
+				exec.RegisterIDToKey(flow.NewRegisterID("", "", "testKey2")),
+			},
+			want: "0.,1.,2.746573744b6579:0.,1.,2.746573744b657932",
+		},
+		"empty keys": {
+			keys:  []ledger.Key{{}, {}},
+			want: ":",
+		},
+		"no keys": {
+			keys:  []ledger.Key{},
+			want: "",
+		},
+	}
+
+	for desc, test := range tests {
+		test := test
+		t.Run(desc, func(t *testing.T) {
+			t.Parallel()
+			got := rest.EncodeKeys(test.keys)
+
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestDecodeKey(t *testing.T) {
+	tests := map[string]struct {
+		key     string
+		want    ledger.Key
+		wantErr assert.ErrorAssertionFunc
+	}{
+		"nominal case": {
+			key: "0.746573744f776e6572,1.74657374436f6e74726f6c6c6572,2.746573744b6579",
+
+			want:    exec.RegisterIDToKey(flow.NewRegisterID("testOwner", "testController", "testKey")),
+			wantErr: assert.NoError,
+		},
+		"empty key parts": {
+			key: "0.,1.,2.746573744b6579",
+
+			want:    exec.RegisterIDToKey(flow.NewRegisterID("", "", "testKey")),
+			wantErr: assert.NoError,
+		},
+		"empty key": {
+			key: "",
+
+			wantErr: assert.Error,
+		},
+	}
+
+	for desc, test := range tests {
+		test := test
+		t.Run(desc, func(t *testing.T) {
+			t.Parallel()
+			got, err := rest.DecodeKey(test.key)
+			test.wantErr(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rs/zerolog v1.22.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
 	google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384 // indirect

--- a/main.go
+++ b/main.go
@@ -111,10 +111,7 @@ func main() {
 	}
 
 	// REST API initialization.
-	rctrl, err := rest.NewController(core)
-	if err != nil {
-		log.Fatal().Err(err).Msg("could not initialize REST controller")
-	}
+	rctrl := rest.NewController(core)
 
 	rsvr := echo.New()
 	rsvr.HideBanner = true


### PR DESCRIPTION
## Goal of this PR

Fixes #26 

This PR adds unit tests for the REST API package. It overs about 90% of lines, the rest being IMO irrelevant to test.

As you might see, there's a weird issue where the `httptest.Recorder` does not record HTTP status codes. This is due to the fact that we directly call the handler instead of going through `echo`'s router, and the handler does not write directly on the `http.ResponseWriter` but lets the router handle it instead by looking at the HTTP error code that it returned as part of its `echo.HTTPError`.

See the following issues for more info:

* https://github.com/gin-gonic/gin/issues/1120
* https://github.com/labstack/echo/issues/593

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date