### PR TITLE
Live Mapping MVP

### DIFF
--- a/cmd/extract-ledger-payloads/main.go
+++ b/cmd/extract-ledger-payloads/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
+	"github.com/optakt/flow-dps/service/synchronizer"
 
 	"github.com/optakt/flow-dps/service/chain"
 	"github.com/optakt/flow-dps/service/feeder"
@@ -103,7 +104,8 @@ func run() int {
 		log.Error().Str("trie", flagTrie).Err(err).Msg("could not initialize feeder")
 		return failure
 	}
-	mapper, err := mapper.New(log, chain, feeder, &Index{},
+	sync := synchronizer.New()
+	mapper, err := mapper.New(log, chain, feeder, sync, &Index{},
 		mapper.WithCheckpointFile(flagCheckpoint),
 		mapper.WithPostProcessing(post),
 	)

--- a/cmd/flow-dps-live/README.md
+++ b/cmd/flow-dps-live/README.md
@@ -1,0 +1,27 @@
+# Flow DPS Live
+
+## Description
+
+The Flow DPS Live binary implements the core functionality to create the index for live sporks.
+It needs the address and ports to access an execution node's pub and req sockets, and an execution state checkpoint.
+The index is generated in the form of a Badger database that allows random access to any ledger register at any block height.
+
+## Usage
+
+```sh
+Usage of flow-dps-live:
+  -n, --node-host           hostname or IP of the live node
+  -p, --pub-port            port on which the pub socket is exposed (default 14532)
+  -r, --req-port            port on which the req socket is exposed (default 14533)
+  -c, --checkpoint string   checkpoint file for state trie
+  -i, --index string        database directory for state index (default "index")
+  -l, --log string          log output level (default "info")
+```
+
+## Example
+
+The following command line starts indexing a live spork from the socket.
+
+```sh
+./flow-dps-live -n 172.17.100.42 -c /var/flow/bootstrap/root.checkpoint -i /var/flow/data/index
+```

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/dgraph-io/badger/v2 v2.2007.2
+	github.com/ef-ds/deque v1.0.4
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8
 	github.com/gammazero/deque v0.1.0
 	github.com/hashicorp/go-multierror v1.0.0
@@ -16,6 +17,7 @@ require (
 	github.com/rs/zerolog v1.22.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
+	go.nanomsg.org/mangos/v3 v3.2.1
 	google.golang.org/grpc v1.37.1
 	google.golang.org/protobuf v1.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/HdrHistogram/hdrhistogram-go v0.9.0 h1:dpujRju0R4M/QZzcnR1LH1qm+TVG3U
 github.com/HdrHistogram/hdrhistogram-go v0.9.0/go.mod h1:nxrse8/Tzg2tg3DZcZjm6qEclQKK70g0KxO61gFFZD4=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
+github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6nK2Q=
+github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.5/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
@@ -205,6 +207,7 @@ github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8/go.mod h1:TA1x
 github.com/gammazero/deque v0.1.0 h1:f9LnNmq66VDeuAlSAapemq/U7hJ2jpIWa4c09q8Dlik=
 github.com/gammazero/deque v0.1.0/go.mod h1:KQw7vFau1hHuM8xmI9RbgKFbAsQFWmBpqQ2KenFLk6M=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
+github.com/gdamore/optopia v0.2.0/go.mod h1:YKYEwo5C1Pa617H7NlPcmQXl+vG6YnSSNB44n8dNL0Q=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -305,6 +308,7 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -903,6 +907,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
+go.nanomsg.org/mangos/v3 v3.2.1 h1:/7pG6tUJO5ZGznG+waoMy6WrurArODDRJu18848oQnw=
+go.nanomsg.org/mangos/v3 v3.2.1/go.mod h1:RxVwsn46YtfJ74mF8MeVo+MFjg545KCI50NuZrFXmzc=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -1049,6 +1055,7 @@ golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/models/dps/live_node.go
+++ b/models/dps/live_node.go
@@ -1,0 +1,7 @@
+package dps
+
+type LiveNodeConfig struct {
+	Host    string
+	SubPort uint16
+	ReqPort uint16
+}

--- a/models/dps/pubsub.go
+++ b/models/dps/pubsub.go
@@ -1,0 +1,8 @@
+package dps
+
+const (
+	TopicTrieUpdates  = "trie_updates"
+	TopicBlockUpdates = "block_updates"
+
+	DefaultPubSubPort = 14532
+)

--- a/service/chain/live_node.go
+++ b/service/chain/live_node.go
@@ -1,0 +1,548 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package chain
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/klauspost/compress/zstd"
+	"github.com/rs/zerolog"
+
+	"go.nanomsg.org/mangos/v3"
+	"go.nanomsg.org/mangos/v3/protocol/req"
+	"go.nanomsg.org/mangos/v3/protocol/sub"
+	_ "go.nanomsg.org/mangos/v3/transport/all" // register transports
+
+	"github.com/onflow/flow-go/model/flow"
+
+	"github.com/optakt/flow-dps/models/dps"
+)
+
+type Synchronizer interface {
+	GetBlockHeight() (uint64, error)
+}
+
+type Live struct {
+	log zerolog.Logger
+
+	sync Synchronizer
+
+	node dps.LiveNodeConfig
+	sub  mangos.Socket
+	req  mangos.Socket
+
+	compressor   *zstd.Encoder
+	decompressor *zstd.Decoder
+
+	blocks blocks
+
+	done chan struct{}
+}
+
+func FromLiveNode(log zerolog.Logger, liveNode dps.LiveNodeConfig, sync Synchronizer) (*Live, error) {
+	compressor, err := zstd.NewWriter(nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize compressor: %w", err)
+	}
+
+	decompressor, err := zstd.NewReader(nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize decompressor: %w", err)
+	}
+
+	live := Live{
+		log: log.With().Str("component", "live-chain").Logger(),
+
+		sync: sync,
+
+		node: liveNode,
+
+		blocks: newBlocks(),
+
+		compressor:   compressor,
+		decompressor: decompressor,
+
+		done: make(chan struct{}),
+	}
+
+	return &live, nil
+}
+
+func (l *Live) Run() error {
+	select {
+	case <-l.done:
+		return nil
+	default:
+	}
+
+	// Connect to the execution node's sockets.
+	err := l.dial()
+	if err != nil {
+		return fmt.Errorf("could not connect to execution node: %w", err)
+	}
+
+	// Upon starting up, retrieve the first three blocks in order to know the current
+	// sealed state of the chain, and how far the live chain needs to catch up.
+	// The first block's height is the reference to set the upper boundary of the
+	// synchronization request.
+	current, err := l.subBlock()
+	if err != nil {
+		return fmt.Errorf("could not get initial blocks: %w", err)
+	}
+	err = l.blocks.cache(current)
+	if err != nil {
+		return fmt.Errorf("could not get cache block: %w", err)
+	}
+	to := current.Header.Height
+
+	// Retrieve two more blocks after the initial one, to make sure that the initial block
+	// is sealed and that the live node is able to produce a sync response that includes
+	// all the requested blocks.
+	for i := 0; i < 2; i++ {
+		block, err := l.subBlock()
+		if err != nil {
+			return fmt.Errorf("could not get initial blocks: %w", err)
+		}
+
+		err = l.blocks.cache(block)
+		if err != nil {
+			return fmt.Errorf("could not get cache block: %w", err)
+		}
+	}
+
+	from, err := l.sync.GetBlockHeight()
+	if err != nil {
+		return fmt.Errorf("could not get current state height: %w", err)
+	}
+
+	// Synchronize with the execution node to receive all missing blocks
+	// in order.
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	stopCache := make(chan struct{})
+	syncFailed := make(chan error)
+	go func() {
+		defer wg.Done()
+		defer close(stopCache)
+
+		for {
+			l.log.Info().Uint64("from", from).Uint64("to", to).Msg("requesting block update sync")
+
+			// Request blocks between two given heights. The node might respond with only a subset of the requested
+			// range, if it is too big, in which case the Live Feeder keeps sending sync requests until it has caught up
+			// with the blocks from the sub socket.
+			err = l.reqSync(from, to)
+			if err != nil {
+				l.log.Error().Err(err).Msg("could not send block sync request")
+				syncFailed <- err
+				return
+			}
+
+			blocks, err := l.recvSync()
+			if err != nil {
+				l.log.Error().Err(err).Msg("could not process block sync response")
+				syncFailed <- err
+				return
+			}
+
+			l.log.Info().Int("sync_blocks", len(blocks)).Msg("received block sync response")
+
+			for _, block := range blocks {
+				l.log.Debug().Uint64("height", block.Header.Height).Msg("received sync block")
+
+				err := l.blocks.add(block)
+				if err != nil {
+					l.log.Error().Err(err).Msg("could not process block sync response")
+					syncFailed <- err
+					return
+				}
+
+				// End of sync reached, stop this routine.
+				if block.Header.Height == to {
+					l.log.Debug().Uint64("height", block.Header.Height).Msg("finished sync!")
+					return
+				}
+
+				// Always keep `from` at the height of the last received block, to avoid requesting multiple times the same data.
+				from = block.Header.Height
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-l.done:
+				return
+			case <-stopCache:
+				return
+			default:
+			}
+
+			block, err := l.subBlock()
+			if err != nil {
+				l.log.Error().Err(err).Msg("could not receive published block update while waiting for sync response")
+				return
+			}
+
+			println("BEFORE CACHE BLOCK")
+			err = l.blocks.cache(block)
+			if err != nil {
+				l.log.Error().Err(err).Msg("received invalid published block update while waiting for sync response")
+				return
+			}
+
+			l.log.Info().Msg("received block while waiting for sync response")
+		}
+	}()
+
+	// Signals that both the caching and syncing routines are done.
+	wait := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(wait)
+	}()
+
+	// Wait for cache to be filled with all required updates to catch up, for the sync process to have failed or for
+	// the chain to be ordered to shut down.
+	select {
+	case <-l.done:
+		return nil
+	case err := <-syncFailed:
+		return err
+	case <-wait:
+		println("DONE WAITING FOR BOTH ROUTINES")
+	}
+
+	// Consume the cache and push its elements to the update channel for
+	// the mapper to use.
+	println("BEFORE CONSUME CACHE")
+	l.blocks.consumeCache()
+
+	l.log.Info().Msg("bootstrapping done, begin live feeding")
+
+	// Start following live updates.
+	for {
+		select {
+		case <-l.done:
+			return nil
+		default:
+		}
+
+		block, err := l.subBlock()
+		if err != nil {
+			return err
+		}
+
+		err = l.blocks.add(block)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (l *Live) Root() (uint64, error) {
+	// Find the lowest height we have available, to use as root height.
+	rootBlock, err := l.blocks.first()
+	if err != nil {
+		return 0, dps.ErrTimeout
+	}
+
+	return rootBlock.Header.Height, nil
+}
+
+func (l *Live) Commit(height uint64) (flow.StateCommitment, error) {
+	// Verify that at least three new blocks have been generated, which
+	// means the block at the height that is being queried is part of
+	// the canonical chain.
+	sealedBlock, err := l.blocks.get(height + 3)
+	if err != nil {
+		return flow.StateCommitment{}, dps.ErrTimeout
+	}
+
+	// Verify that the height at which we want to get the state
+	// commitment is also available in our map.
+	wantBlock, err := l.blocks.get(height)
+	if err != nil {
+		return flow.StateCommitment{}, dps.ErrTimeout
+	}
+
+	// Look for the seal of the block whose state we want.
+	var seal *flow.Seal
+	for _, s := range sealedBlock.Payload.Seals {
+		if s.BlockID == wantBlock.ID() {
+			seal = s
+		}
+	}
+
+	// If none is found, time out.
+	if seal == nil {
+		return flow.StateCommitment{}, dps.ErrTimeout
+	}
+
+	return seal.FinalState, nil
+}
+
+func (l *Live) Header(height uint64) (*flow.Header, error) {
+	// Verify that at least three new blocks have been generated, which
+	// means the block at the height that is being queried is part of
+	// the canonical chain.
+	_, err := l.blocks.get(height + 3)
+	if err != nil {
+		return nil, dps.ErrTimeout
+	}
+
+	block, err := l.blocks.get(height)
+	if err != nil {
+		return nil, dps.ErrTimeout
+	}
+
+	// Delete block since Header is the last call for each block from the mapper
+	l.blocks.delete(height)
+
+	return block.Header, nil
+}
+
+func (l *Live) Events(_ uint64) ([]flow.Event, error) {
+	// Not implemented, but should not panic since it is used.
+	// TODO: Implement this. (https://github.com/optakt/flow-dps/issues/99)
+	return nil, nil
+}
+
+func (l *Live) Stop() {
+	close(l.done)
+}
+
+func (l *Live) dial() error {
+	psock, err := sub.NewSocket()
+	if err != nil {
+		return fmt.Errorf("could not get new sub socket: %w", err)
+	}
+
+	// TODO: Switch to WSS (https://github.com/optakt/flow-dps/issues/97)
+	err = psock.Dial(fmt.Sprint("ws://", l.node.Host, ":", l.node.SubPort))
+	if err != nil {
+		return fmt.Errorf("could not dial on sub socket: %w", err)
+	}
+	err = psock.SetOption(mangos.OptionSubscribe, []byte("pub_block"))
+	if err != nil {
+		return fmt.Errorf("could not subscribe: %w", err)
+	}
+
+	rsock, err := req.NewSocket()
+	if err != nil {
+		return fmt.Errorf("could not get new req socket: %w", err)
+	}
+	err = rsock.Dial(fmt.Sprint("tcp://", l.node.Host, ":", l.node.ReqPort))
+	if err != nil {
+		return fmt.Errorf("could not dial on req socket: %w", err)
+	}
+
+	l.sub = psock
+	l.req = rsock
+
+	return nil
+}
+
+func (l *Live) subBlock() (*flow.Block, error) {
+	msg, err := l.sub.Recv()
+	if err != nil {
+		l.log.Warn().Err(err).Msg("could not receive block")
+		return nil, err
+	}
+
+	l.log.Info().Msg("received block update")
+
+	// Get payload from message by removing topic header.
+	payload := bytes.TrimPrefix(msg, []byte("pub_block"))
+
+	decoded, err := l.decompressor.DecodeAll(payload, nil)
+	if err != nil {
+		l.log.Error().Err(err).Msg("unable to decompress block payload")
+		return nil, err
+	}
+
+	var block flow.Block
+	err = cbor.Unmarshal(decoded, &block)
+	if err != nil {
+		l.log.Error().Err(err).Msg("unable to decode block payload")
+		return nil, err
+	}
+
+	return &block, nil
+}
+
+func (l *Live) reqSync(from, to uint64) error {
+	request := struct {
+		From uint64
+		To   uint64
+	}{
+		From: from,
+		To:   to,
+	}
+
+	payload, err := cbor.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	compressed := l.compressor.EncodeAll(payload, nil)
+
+	// Add header "topic".
+	message := append([]byte(`sync_block`), compressed...)
+
+	l.log.Debug().Uint64("from", from).Uint64("to", to).Msg("sending sync request")
+
+	return l.req.Send(message)
+}
+
+func (l *Live) recvSync() ([]*flow.Block, error) {
+	msg, err := l.req.Recv()
+	if err != nil {
+		l.log.Warn().Err(err).Msg("could not receive sync response")
+		return nil, err
+	}
+
+	l.log.Info().Msg("received block sync response")
+
+	payload, err := l.decompressor.DecodeAll(msg, nil)
+	if err != nil {
+		l.log.Error().Err(err).Msg("unable to decompress block sync payload")
+		return nil, err
+	}
+
+	// Check if the sync server answered with an error response.
+	var syncErr error
+	err = cbor.Unmarshal(payload, &syncErr)
+	if err == nil {
+		return nil, syncErr
+	}
+
+	// If it did not, the message contains a block and it can be unmarshalled.
+	var blocks []*flow.Block
+	err = cbor.Unmarshal(payload, &blocks)
+	if err != nil {
+		l.log.Error().Err(err).Msg("unable to decode block sync payload")
+		return nil, err
+	}
+
+	return blocks, nil
+}
+
+// This structure is a simple short-term cache for blocks.
+type blocks struct {
+	// The cached map is used to cache blocks that should not be
+	// used yet, as they do not follow the current state of the
+	// chain. It is merged with the blocks map once the
+	// synchronization process is complete.
+	cached map[uint64]*flow.Block
+
+	// The blocks map contains the blocks that should be handled by the
+	// mapper immediately. While the sync process takes place, it is
+	// progressively filled. Once the sync process is over, it is kept
+	// up-to-date by the pub/sub mechanism.
+	blocksMu sync.RWMutex
+	blocks   map[uint64]*flow.Block
+}
+
+func newBlocks() blocks {
+	println("INIT MAP")
+	return blocks{
+		cached: make(map[uint64]*flow.Block),
+		blocks: make(map[uint64]*flow.Block),
+	}
+}
+
+func (b *blocks) add(block *flow.Block) error {
+	if block == nil {
+		return errors.New("nil block")
+	}
+
+	b.blocksMu.Lock()
+	b.blocks[block.Header.Height] = block
+	b.blocksMu.Unlock()
+
+	return nil
+}
+
+func (b *blocks) cache(block *flow.Block) error {
+	if block == nil {
+		return errors.New("nil block")
+	}
+	println("WRITE IN CACHE")
+
+	b.cached[block.Header.Height] = block
+
+	println("WRITE IN CACHE ALL GOOD")
+
+	return nil
+}
+
+func (b *blocks) consumeCache() {
+	println("EAT CACHE")
+
+	b.blocksMu.Lock()
+	for height, block := range b.cached {
+		b.blocks[height] = block
+	}
+	b.blocksMu.Unlock()
+
+	b.cached = nil
+}
+
+func (b *blocks) get(height uint64) (*flow.Block, error) {
+	b.blocksMu.RLock()
+	block, exists := b.blocks[height]
+	b.blocksMu.RUnlock()
+
+	if !exists {
+		return nil, errors.New("block not found")
+	}
+
+	return block, nil
+}
+
+func (b *blocks) delete(height uint64) {
+	b.blocksMu.Lock()
+	delete(b.blocks, height)
+	b.blocksMu.Unlock()
+}
+
+func (b *blocks) first() (*flow.Block, error) {
+	b.blocksMu.RLock()
+	defer b.blocksMu.RUnlock()
+
+	if len(b.blocks) == 0 {
+		return nil, errors.New("no blocks ready")
+	}
+
+	var minHeight uint64
+	for minHeight = range b.blocks {
+		break
+	}
+	for height := range b.blocks {
+		if height < minHeight {
+			minHeight = height
+		}
+	}
+
+	return b.blocks[minHeight], nil
+}

--- a/service/feeder/live_node.go
+++ b/service/feeder/live_node.go
@@ -1,0 +1,345 @@
+package feeder
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/ef-ds/deque"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/klauspost/compress/zstd"
+	"github.com/rs/zerolog"
+
+	"go.nanomsg.org/mangos/v3"
+	"go.nanomsg.org/mangos/v3/protocol/req"
+	"go.nanomsg.org/mangos/v3/protocol/sub"
+	_ "go.nanomsg.org/mangos/v3/transport/all" // register transports
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/optakt/flow-dps/models/dps"
+)
+
+type Synchronizer interface {
+	GetRootHash() (ledger.RootHash, error)
+}
+
+type Live struct {
+	log zerolog.Logger
+
+	sync Synchronizer
+
+	node dps.LiveNodeConfig
+
+	sub mangos.Socket
+	req mangos.Socket
+
+	updates chan *ledger.TrieUpdate
+
+	cache        deque.Deque
+	compressor   *zstd.Encoder
+	decompressor *zstd.Decoder
+
+	done chan struct{}
+}
+
+func FromLiveNode(log zerolog.Logger, liveNode dps.LiveNodeConfig, sync Synchronizer) (*Live, error) {
+	compressor, err := zstd.NewWriter(nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize compressor: %w", err)
+	}
+
+	decompressor, err := zstd.NewReader(nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize decompressor: %w", err)
+	}
+
+	live := Live{
+		log: log.With().Str("component", "live-feeder").Logger(),
+
+		sync: sync,
+
+		node: liveNode,
+
+		compressor:   compressor,
+		decompressor: decompressor,
+
+		done: make(chan struct{}),
+	}
+
+	return &live, nil
+}
+
+func (l *Live) Run() error {
+	select {
+	case <-l.done:
+		return nil
+	default:
+	}
+
+	// Connect to the execution node's sockets.
+	err := l.dial()
+	if err != nil {
+		return fmt.Errorf("could not connect to execution node: %w", err)
+	}
+
+	// Upon starting up, retrieve the first update in order to know the current
+	// state of the network, and how far the live feeder needs to catch up.
+	current, err := l.subUpdate()
+	if err != nil {
+		return fmt.Errorf("could not get initial trie update: %w", err)
+	}
+
+	l.cache.PushBack(current)
+
+	from, err := l.sync.GetRootHash()
+	if err != nil {
+		return fmt.Errorf("could not get current state root hash: %w", err)
+	}
+
+	to := current.RootHash
+
+	// Retrieve 20 more trie updates after the initial one, to make sure that the initial one
+	// is part of a sealed block and that the live node is able to produce a sync response that includes
+	// all the requested trie updates.
+	for i := 0; i < 20; i++ {
+		update, err := l.subUpdate()
+		if err != nil {
+			return fmt.Errorf("could not get initial updates: %w", err)
+		}
+
+		l.cache.PushBack(update)
+	}
+
+	// Synchronize with the execution node to receive all missing updates
+	// in order.
+	wait := make(chan struct{})
+	syncFailed := make(chan error)
+	go func() {
+		defer close(wait)
+
+		for {
+			l.log.Info().Hex("from", from[:]).Hex("to", to[:]).Msg("requesting trie update sync")
+
+			// Request trie updates between two given root hashes. The node might respond with only a subset of the requested
+			// range, if it is too big, in which case the Live Feeder keeps sending sync requests until it has caught up
+			// with the updates from the sub socket.
+			err = l.reqSync(from, to)
+			if err != nil {
+				l.log.Error().Err(err).Msg("could not send trie sync request")
+				syncFailed <- err
+				return
+			}
+
+			updates, err := l.recvSync()
+			if err != nil {
+				l.log.Error().Err(err).Msg("could not process trie sync response")
+				syncFailed <- err
+				return
+			}
+
+			l.log.Info().Int("sync_updates", len(updates)).Msg("received trie sync response")
+
+			for _, update := range updates {
+				l.log.Debug().Hex("hash", update.RootHash[:]).Msg("received sync response")
+
+				l.updates <- &update
+
+				// End of sync reached, stop this routine.
+				if update.RootHash == to {
+					return
+				}
+
+				// Always keep `from` at the rootHash of the last update, to avoid requesting multiple times the same data.
+				from = update.RootHash
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-wait:
+				return
+			case <-l.done:
+				return
+			default:
+			}
+
+			update, err := l.subUpdate()
+			if err != nil {
+				l.log.Error().Err(err).Msg("could not receive published trie update while waiting for sync response")
+				syncFailed <- err
+				return
+			}
+
+			l.log.Info().Msg("caching update while waiting for sync response")
+
+			l.cache.PushBack(update)
+		}
+	}()
+
+	// Wait for cache to be filled with all required updates to catch up.
+	select {
+	case <-l.done:
+		return nil
+	case err := <-syncFailed:
+		return err
+	case <-wait:
+	}
+
+	l.log.Info().Msg("bootstrapping done, unstack cached updates")
+
+	// Consume the cache and push its elements to the update channel for
+	// the mapper to use.
+	for l.cache.Len() > 0 {
+		cached, _ := l.cache.PopFront()
+		update, ok := cached.(*ledger.TrieUpdate)
+		if !ok {
+			return errors.New("invalid update in cache")
+		}
+
+		l.updates <- update
+	}
+
+	l.log.Info().Msg("cached updates consumed, begin live feeding")
+
+	// Start following live updates.
+	for {
+		select {
+		case <-l.done:
+			return nil
+		default:
+		}
+
+		update, err := l.subUpdate()
+		if err != nil {
+			return err
+		}
+
+		l.updates <- update
+	}
+}
+
+func (l *Live) Update() (*ledger.TrieUpdate, error) {
+	return <-l.updates, nil
+}
+
+func (l *Live) Stop() {
+	close(l.done)
+}
+
+func (l *Live) dial() error {
+	psock, err := sub.NewSocket()
+	if err != nil {
+		return fmt.Errorf("could not get new sub socket: %w", err)
+	}
+
+	// TODO: Switch to WSS (https://github.com/optakt/flow-dps/issues/97)
+	err = psock.Dial(fmt.Sprint("ws://", l.node.Host, ":", l.node.SubPort))
+	if err != nil {
+		return fmt.Errorf("could not dial on sub socket: %w", err)
+	}
+	err = psock.SetOption(mangos.OptionSubscribe, []byte("pub_trie"))
+	if err != nil {
+		return fmt.Errorf("could not subscribe: %w", err)
+	}
+
+	rsock, err := req.NewSocket()
+	if err != nil {
+		return fmt.Errorf("could not get new req socket: %w", err)
+	}
+	err = rsock.Dial(fmt.Sprint("tcp://", l.node.Host, ":", l.node.ReqPort))
+	if err != nil {
+		return fmt.Errorf("could not dial on req socket: %w", err)
+	}
+
+	l.sub = psock
+	l.req = rsock
+
+	return nil
+}
+
+func (l *Live) subUpdate() (*ledger.TrieUpdate, error) {
+	msg, err := l.sub.Recv()
+	if err != nil {
+		l.log.Warn().Err(err).Msg("could not receive update")
+		return nil, err
+	}
+
+	l.log.Info().Msg("received trie update")
+
+	// Get payload from message by removing topic header.
+	payload := bytes.TrimPrefix(msg, []byte("pub_trie"))
+
+	decoded, err := l.decompressor.DecodeAll(payload, nil)
+	if err != nil {
+		l.log.Error().Err(err).Msg("unable to decompress trie update payload")
+		return nil, err
+	}
+
+	var update ledger.TrieUpdate
+	err = cbor.Unmarshal(decoded, &update)
+	if err != nil {
+		l.log.Error().Err(err).Msg("unable to decode trie update payload")
+		return nil, err
+	}
+
+	return &update, nil
+}
+
+func (l *Live) reqSync(from, to ledger.RootHash) error {
+	request := struct {
+		From ledger.RootHash
+		To   ledger.RootHash
+	}{
+		From: from,
+		To:   to,
+	}
+
+	payload, err := cbor.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	compressed := l.compressor.EncodeAll(payload, nil)
+
+	// Add header "topic".
+	message := append([]byte(`sync_trie`), compressed...)
+
+	l.log.Debug().Str("from", from.String()).Str("to", to.String()).Msg("sending sync request")
+
+	return l.req.Send(message)
+}
+
+func (l *Live) recvSync() ([]ledger.TrieUpdate, error) {
+	msg, err := l.req.Recv()
+	if err != nil {
+		l.log.Warn().Err(err).Msg("could not receive sync response")
+		return nil, err
+	}
+
+	l.log.Info().Msg("received trie sync response")
+
+	payload, err := l.decompressor.DecodeAll(msg, nil)
+	if err != nil {
+		l.log.Error().Err(err).Msg("unable to decompress trie sync payloads")
+		return nil, err
+	}
+
+	// Check if the sync server answered with an error response.
+	var syncErr error
+	err = cbor.Unmarshal(payload, &syncErr)
+	if err == nil {
+		return nil, syncErr
+	}
+
+	// If it did not, the message contains a trie update and it can be unmarshalled.
+	var updates []ledger.TrieUpdate
+	err = cbor.Unmarshal(payload, &updates)
+	if err != nil {
+		l.log.Error().Err(err).Msg("unable to decode trie sync payload")
+		return nil, err
+	}
+
+	return updates, nil
+}

--- a/service/mapper/synchronizer.go
+++ b/service/mapper/synchronizer.go
@@ -1,0 +1,22 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package mapper
+
+import "github.com/onflow/flow-go/ledger"
+
+type Synchronizer interface {
+	SetRootHash(ledger.RootHash)
+	SetBlockHeight(uint64)
+}

--- a/service/synchronizer/synchronizer.go
+++ b/service/synchronizer/synchronizer.go
@@ -1,0 +1,55 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package synchronizer
+
+import (
+	"errors"
+
+	"github.com/onflow/flow-go/ledger"
+)
+
+type Synchronizer struct {
+	rootHash    *ledger.RootHash
+	blockHeight *uint64
+}
+
+func New() *Synchronizer {
+	// FIXME: What happens if we already had an index file and we're not rebuilding it from scratch?
+	return &Synchronizer{}
+}
+
+func (s *Synchronizer) SetRootHash(h ledger.RootHash) {
+	s.rootHash = &h
+}
+
+func (s *Synchronizer) GetRootHash() (ledger.RootHash, error) {
+	if s.rootHash == nil {
+		return ledger.RootHash{}, errors.New("no root hash set yet")
+	}
+
+	return *s.rootHash, nil
+}
+
+func (s *Synchronizer) SetBlockHeight(height uint64) {
+	s.blockHeight = &height
+}
+
+func (s *Synchronizer) GetBlockHeight() (uint64, error) {
+	if s.blockHeight == nil {
+		return 0, errors.New("no root hash set yet")
+	}
+
+	return *s.blockHeight, nil
+}


### PR DESCRIPTION
## Goal of this PR

Part of #25 

This PR currently:

* Implements a basic version of the Live Feeder
* Adds a scaffolding of the Network Chain

In order to test it, you need to use my fork of Flow-Go on the branch [`dps-access`](https://github.com/Ullaakut/flow-go/tree/dps-access).

## TODO

- [x] Implement Network Chain.
	- [x] Implement multi-topic support.
	- [x] Switch encoding from JSON to something else.
- [x] Make the pubsub socket have multiple message types (Trie Updates for the Feeder, Blocks for the Chain, and later on Events and Bootstrapping messages as well).
- [x] Make the mapper use those two new components.
- [ ] Handle pubsub socket disconnects and reconnect automatically.
- [ ] Update Documentation to mention new Feeder and Chain implementations.

## TODO in other(s) PR(s)

- [ ] Handle missing updates and send requests to exec node for missing information
- [ ] Handle bootstrapping
- [ ] Handle events
- [ ] Switch from WS protocol to WSS

## Checklist

- [x] Is on the right branch
- [ ] Documentation is up-to-date
- [ ] Tests are up-to-date