### PR TITLE
Create index snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/cmd/create-index-snapshot/create-index-snapshot
 /cmd/extract-block-events/extract-block-events
 /cmd/extract-block-headers/extract-block-headers
 /cmd/extract-ledger-payloads/extract-ledger-payloads

--- a/cmd/create-index-snapshot/README.md
+++ b/cmd/create-index-snapshot/README.md
@@ -14,9 +14,9 @@ Usage of ./create-index-snapshot:
   -l, --log-level string   log level for JSON logger (default "info")
 ```
 
-## Example program that restores a database
+## Example Program That Restores a Database
 
-Program below opens a read-only in-memory badger database and restores the state from the created backup. Error handling is omitted for brevity.
+The program below opens a read-only in-memory badger database and restores the state from the created backup. Error handling is omitted for brevity.
 
 ```go
 opts := badger.DefaultOptions("").WithInMemory(true).WithReadOnly(true).WithLogger(nil)

--- a/cmd/create-index-snapshot/README.md
+++ b/cmd/create-index-snapshot/README.md
@@ -1,0 +1,31 @@
+# Create Index Snapshot
+
+## Description
+
+This utility binary can be used to create a snapshot of an existing index. When a path to the index (badger database) is specified, the badger API is used to create a backup. This backup is compressed with Zstandard compression, encoded to hex and printed on standard output.
+
+This output can be used to restore a database from a previous snapshot.
+
+## Usage
+
+```sh
+Usage of ./create-index-snapshot:
+  -d, --dir string         path to badger database
+  -l, --log-level string   log level for JSON logger (default "info")
+```
+
+## Example program that restores a database
+
+Program below opens a read-only in-memory badger database and restores the state from the created backup. Error handling is omitted for brevity.
+
+```go
+opts := badger.DefaultOptions("").WithInMemory(true).WithReadOnly(true).WithLogger(nil)
+db, _ := badger.Open(opts)
+
+payload := "output of create-index-snapshot"
+
+dbSnapshot, _ := zstd.NewReader(hex.NewDecoder(strings.NewReader(payload)))
+defer dbSnapshot.Close()
+
+db.Load(dbSnapshot, 10)
+```

--- a/cmd/create-index-snapshot/main.go
+++ b/cmd/create-index-snapshot/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/spf13/pflag"
+)
+
+func main() {
+
+	var (
+		flagDir      string
+		flagLogLevel string
+	)
+
+	pflag.StringVarP(&flagDir, "dir", "d", "", "path to badger database")
+	pflag.StringVarP(&flagLogLevel, "log-level", "l", "info", "log level for JSON logger")
+
+	pflag.Parse()
+
+	zerolog.TimestampFunc = func() time.Time { return time.Now() }
+	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.DebugLevel)
+	level, err := zerolog.ParseLevel(flagLogLevel)
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+
+	log = log.Level(level)
+
+	if flagDir == "" {
+		log.Fatal().Msg("path to badger database is required")
+	}
+
+	opts := badger.DefaultOptions(flagDir).WithReadOnly(true)
+	db, err := badger.Open(opts)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not open badger db")
+	}
+
+	defer db.Close()
+
+	var buf bytes.Buffer
+	_, err = db.Backup(&buf, 0)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not backup badger db")
+	}
+
+	fmt.Printf("%s", hex.EncodeToString(buf.Bytes()))
+}


### PR DESCRIPTION
## Goal of this PR

This PR adds a command-line utility that can be used to create a snapshot of an existing index. When a path to the index (badger database) is specified, the badger API is used to create a backup. This backup is compressed with Zstandard compression, encoded to hex and printed on standard output.

This output can be used to restore a database from a previous snapshot.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [ ] ~Tests are up-to-date~