### PR TITLE
Add unit tests to state package

### DIFF
--- a/service/state/commit_test.go
+++ b/service/state/commit_test.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestCommit_ForHeight(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	commit := c.Commit()
+
+	t.Run("should return matching commit for height", func(t *testing.T) {
+		got, err := commit.ForHeight(lastHeight)
+		assert.NoError(t, err)
+		assert.Equal(t, lastCommit, got)
+	})
+
+	t.Run("should return error for unindexed height", func(t *testing.T) {
+		got, err := commit.ForHeight(lastHeight * 2)
+		assert.Error(t, err)
+		assert.Equal(t, flow.StateCommitment{}, got)
+	})
+}

--- a/service/state/core_test.go
+++ b/service/state/core_test.go
@@ -1,0 +1,135 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/complete"
+	"github.com/onflow/flow-go/model/flow"
+
+	"github.com/optakt/flow-dps/service/storage"
+)
+
+var (
+	lastHeight = uint64(42)
+	lastCommit = flow.StateCommitment{132, 131, 130, 129, 128, 127, 126, 125, 124, 123, 122, 121, 120, 119, 118, 117, 116, 115, 114, 113, 112, 111, 110, 19, 18, 17, 16, 15, 14, 13, 12, 11}
+
+	testBlockID   = flow.Identifier{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}
+	testEventType = flow.EventType("testType")
+	testEvents    = []flow.Event{{Type: testEventType}, {Type: testEventType}, {Type: testEventType}}
+	testHeader    = &flow.Header{ChainID: "test-chain"}
+	testKeyParts  = []ledger.KeyPart{{Type: 0, Value: []byte(`testOwner`)}, {Type: 1, Value: []byte(`testController`)}, {Type: 2, Value: []byte(`testKey`)}}
+	testKey       = ledger.Key{KeyParts: testKeyParts}
+	testKeys      = []ledger.Key{testKey, testKey, testKey}
+	testValue     = []byte(`testValue`)
+	testValues    = []ledger.Value{testValue, testValue, testValue}
+	testPayload   = &ledger.Payload{Key: testKey, Value: testValue}
+	testKeyHex    = []byte{139, 55, 7, 236, 49, 129, 213, 248, 52, 211, 245, 24, 153, 110, 242, 149, 113, 114, 147, 169, 240, 99, 17, 107, 174, 82, 185, 178, 170, 228, 221, 138}
+	testPath, _   = ledger.ToPath(testKeyHex)
+)
+
+func TestCore_Ledger(t *testing.T) {
+	c := &Core{}
+	l := c.Ledger()
+
+	led, ok := l.(*Ledger)
+	assert.True(t, ok)
+
+	assert.Equal(t, c, led.core)
+	assert.Equal(t, uint8(complete.DefaultPathFinderVersion), led.version)
+}
+
+func TestCore_payload(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{
+		db:     db,
+		height: lastHeight,
+		commit: lastCommit,
+	}
+
+	t.Run("should return proper payload on known key path", func(t *testing.T) {
+		payload, err := c.payload(lastHeight, testPath)
+		assert.NoError(t, err)
+		assert.Equal(t, testPayload, payload)
+	})
+
+	t.Run("should return empty payload on unknown key path", func(t *testing.T) {
+		payload, err := c.payload(lastHeight, ledger.Path{})
+		assert.NoError(t, err)
+		assert.Equal(t, ledger.EmptyPayload(), payload)
+	})
+
+	t.Run("should error when given a height above last indexed height", func(t *testing.T) {
+		p, err := c.payload(2*lastHeight, ledger.Path{})
+		assert.Error(t, err)
+		assert.Nil(t, p)
+	})
+}
+
+func inMemoryDB(t *testing.T) *badger.DB {
+	t.Helper()
+
+	opts := badger.DefaultOptions("")
+	opts.InMemory = true
+	opts.Logger = nil
+
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	err = db.Update(func(txn *badger.Txn) error {
+		err = storage.SavePayload(lastHeight, testPath, testPayload)(txn)
+		if err != nil {
+			return err
+		}
+
+		err = storage.SaveCommitForHeight(lastCommit, lastHeight)(txn)
+		if err != nil {
+			return err
+		}
+
+		err = storage.SaveHeightForCommit(lastHeight, lastCommit)(txn)
+		if err != nil {
+			return err
+		}
+
+		err = storage.SaveHeaderForHeight(lastHeight, testHeader)(txn)
+		if err != nil {
+			return err
+		}
+
+		err = storage.SaveEvents(lastHeight, testEventType, testEvents)(txn)
+		if err != nil {
+			return err
+		}
+
+		err = storage.SaveHeightForBlock(testBlockID, lastHeight-1)(txn)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return db
+}

--- a/service/state/data_test.go
+++ b/service/state/data_test.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestData_Header(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	data := c.Data()
+
+	t.Run("should return matching header for height", func(t *testing.T) {
+		got, err := data.Header(lastHeight)
+		assert.NoError(t, err)
+		assert.Equal(t, testHeader, got)
+	})
+
+	t.Run("should return error for unindexed height", func(t *testing.T) {
+		got, err := data.Header(lastHeight * 2)
+		assert.Error(t, err)
+		assert.Equal(t, &flow.Header{}, got)
+	})
+}
+
+func TestData_Events(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db, height: lastHeight}
+	data := c.Data()
+
+	t.Run("should return matching events for height", func(t *testing.T) {
+		got, err := data.Events(lastHeight)
+		assert.NoError(t, err)
+		assert.Equal(t, testEvents, got)
+	})
+
+	t.Run("should return error for unindexed height", func(t *testing.T) {
+		got, err := data.Events(lastHeight * 2)
+		assert.Error(t, err)
+		assert.Nil(t, got)
+	})
+}

--- a/service/state/height_test.go
+++ b/service/state/height_test.go
@@ -1,0 +1,61 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestHeight_ForBlock(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	h := c.Height()
+
+	t.Run("should return matching height for blockID", func(t *testing.T) {
+		gotHeight, err := h.ForBlock(testBlockID)
+		assert.NoError(t, err)
+		assert.Equal(t, lastHeight-1, gotHeight)
+	})
+
+	t.Run("should return error for unindexed blockID", func(t *testing.T) {
+		_, err := h.ForBlock(flow.Identifier{})
+		assert.Error(t, err)
+	})
+}
+
+func TestHeight_ForCommit(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	h := c.Height()
+
+	t.Run("should return matching height for commit", func(t *testing.T) {
+		gotHeight, err := h.ForCommit(lastCommit)
+		assert.NoError(t, err)
+		assert.Equal(t, lastHeight, gotHeight)
+	})
+
+	t.Run("should return error for unindexed commit", func(t *testing.T) {
+		_, err := h.ForCommit(flow.StateCommitment{})
+		assert.Error(t, err)
+	})
+}

--- a/service/state/index_test.go
+++ b/service/state/index_test.go
@@ -1,0 +1,91 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-go/ledger"
+)
+
+func TestIndex_Header(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	idx := c.Index()
+
+	err := idx.Header(lastHeight, testHeader)
+	assert.NoError(t, err)
+}
+
+func TestIndex_Commit(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	idx := c.Index()
+
+	err := idx.Commit(lastHeight, lastCommit)
+	assert.NoError(t, err)
+}
+
+func TestIndex_Payloads(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	idx := c.Index()
+
+	t.Run("nominal case", func(t *testing.T) {
+		err := idx.Payloads(lastHeight, []ledger.Path{testPath}, []*ledger.Payload{testPayload})
+		assert.NoError(t, err)
+	})
+
+	t.Run("errors when length of paths and payloads mismatch", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("path and payload length mismatch should panic")
+			}
+		}()
+
+		err := idx.Payloads(lastHeight, []ledger.Path{testPath, testPath}, []*ledger.Payload{testPayload})
+		assert.Error(t, err)
+	})
+}
+
+func TestIndex_Events(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	idx := c.Index()
+
+	err := idx.Events(lastHeight, testEvents)
+	assert.NoError(t, err)
+}
+
+func TestIndex_Last(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	idx := c.Index()
+
+	err := idx.Last(lastCommit)
+	assert.NoError(t, err)
+}

--- a/service/state/last_test.go
+++ b/service/state/last_test.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLast_Height(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db, height: lastHeight}
+	last := c.Last()
+
+	got := last.Height()
+	assert.Equal(t, lastHeight, got)
+}
+
+func TestLast_Commit(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db, commit: lastCommit}
+	last := c.Last()
+
+	got := last.Commit()
+	assert.Equal(t, lastCommit, got)
+}

--- a/service/state/ledger_test.go
+++ b/service/state/ledger_test.go
@@ -1,0 +1,72 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/ledger"
+)
+
+func TestLedger_WithVersion(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	l := c.Ledger().WithVersion(47)
+
+	ldgr, ok := l.(*Ledger)
+	require.True(t, ok)
+
+	assert.Equal(t, uint8(47), ldgr.version)
+}
+
+func TestLedger_Get(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db, height: lastHeight}
+	l := c.Ledger()
+
+	t.Run("nominal case", func(t *testing.T) {
+		query, err := ledger.NewQuery(ledger.State(lastCommit), testKeys)
+		require.NoError(t, err)
+
+		got, err := l.Get(query)
+		assert.NoError(t, err)
+		assert.Equal(t, testValues, got)
+	})
+
+	t.Run("keys not found", func(t *testing.T) {
+		query, err := ledger.NewQuery(ledger.State(lastCommit), []ledger.Key{})
+		require.NoError(t, err)
+
+		got, err := l.Get(query)
+		assert.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("unknown state", func(t *testing.T) {
+		query, err := ledger.NewQuery(ledger.State{}, testKeys)
+		require.NoError(t, err)
+
+		got, err := l.Get(query)
+		assert.Error(t, err)
+		assert.Empty(t, got)
+	})
+}

--- a/service/state/raw_test.go
+++ b/service/state/raw_test.go
@@ -1,0 +1,55 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRaw_WithHeight(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db}
+	r := c.Raw().WithHeight(47)
+
+	raw, ok := r.(*Raw)
+	require.True(t, ok)
+
+	assert.Equal(t, uint64(47), raw.height)
+}
+
+func TestRaw_Get(t *testing.T) {
+	db := inMemoryDB(t)
+	defer db.Close()
+
+	c := &Core{db: db, height: lastHeight}
+	r := c.Raw().WithHeight(lastHeight)
+
+	t.Run("nominal case", func(t *testing.T) {
+		got, err := r.Get(testKeyHex)
+		assert.NoError(t, err)
+		assert.Equal(t, testValue, got)
+	})
+
+	t.Run("invalid key format", func(t *testing.T) {
+		got, err := r.Get([]byte(`invalid key`))
+		assert.Error(t, err)
+		assert.Nil(t, got)
+	})
+}


### PR DESCRIPTION
## Goal of this PR

Fixes #31 

This PR also adds some small changes to the unit tests of the chain package, in order to make sure that each test closes their in-memory badger DB and that hash-based types are initialized properly from hex strings.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date