### PR TITLE
Adding utility to execute cadence scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/cmd/execute-cadence-script/execute-cadence-script
 /cmd/create-index-snapshot/create-index-snapshot
 /cmd/extract-block-events/extract-block-events
 /cmd/extract-block-headers/extract-block-headers

--- a/cmd/execute-cadence-script/README.md
+++ b/cmd/execute-cadence-script/README.md
@@ -1,0 +1,51 @@
+# Execute Cadence Script
+
+## Description
+
+This utility binary can be used to execute a Cadence script against a running Flow network. By default, access nodes are expected on localhost:3569. Script can be executed on an arbitrary block height.
+
+## Usage
+
+```sh
+Usage of ./execute-cadence-script:
+  -a, --api string           access node API address (default "localhost:3569")
+  -h, --height int           height on which to execute script (default -1)
+  -l, --log-level string     log level for JSON logger (default "info")
+  -s, --script-file string   cadence script to execute
+```
+## Example
+
+The example executes a Cadence script to retrieve the balance of an account '0x631e88ae7f1d7c20' at two different block heights.
+
+```console
+$ ./execute-cadence-script -s get_balance.ca
+100.00100004
+
+$ ./execute-cadence-script -h 90 -s get_balance.ca
+100.00100005
+
+$ cat ./get_balance.ca
+// This script reads the balance field of an account's FlowToken Balance
+
+import FungibleToken from 0x9a0766d93b6608b7
+import FlowToken from 0x7e60df042a9c0868
+
+pub fun main(): UFix64 {
+
+    // note that the account address is currently 
+    // in the script itself, provided to the util
+    var account: Address = 0x631e88ae7f1d7c20
+
+        let vaultRef = getAccount(account)
+        .getCapability(/public/flowTokenBalance)
+        .borrow<&FlowToken.Vault{FungibleToken.Balance}>()
+        ?? panic("Could not borrow Balance reference to the Vault")
+
+        return vaultRef.balance
+}
+```
+
+## TODOs:
+
+- internally, height argument is `int64`, not `uint64`. this was done so that `-1` height can be used as the sentinel value for `latest` height
+- templating for variable substitution?

--- a/cmd/execute-cadence-script/main.go
+++ b/cmd/execute-cadence-script/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/flow-go-sdk/client"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/pflag"
+	"google.golang.org/grpc"
+)
+
+func main() {
+
+	var (
+		flagAPI        string
+		flagScriptFile string
+		flagLogLevel   string
+		flagHeight     int64
+	)
+
+	// TODO: mismatch between block height type - using int64 instead of uint64
+
+	pflag.StringVarP(&flagScriptFile, "script-file", "s", "", "cadence script to execute")
+	pflag.StringVarP(&flagAPI, "api", "a", "localhost:3569", "access node API address")
+	pflag.StringVarP(&flagLogLevel, "log-level", "l", "info", "log level for JSON logger")
+	pflag.Int64VarP(&flagHeight, "height", "h", -1, "height on which to execute script")
+
+	pflag.Parse()
+
+	zerolog.TimestampFunc = func() time.Time { return time.Now() }
+	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.DebugLevel)
+	level, err := zerolog.ParseLevel(flagLogLevel)
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+
+	log = log.Level(level)
+
+	cli, err := client.New(flagAPI, grpc.WithInsecure())
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not connect to the access node")
+	}
+
+	script, err := ioutil.ReadFile(flagScriptFile)
+	if err != nil {
+		log.Fatal().Err(err).Str("file", flagScriptFile).Msg("could not read script file")
+	}
+
+	var value cadence.Value
+	if flagHeight == -1 {
+		value, err = cli.ExecuteScriptAtLatestBlock(context.Background(), script, []cadence.Value{})
+	} else {
+		value, err = cli.ExecuteScriptAtBlockHeight(context.Background(), uint64(flagHeight), script, []cadence.Value{})
+	}
+
+	if err != nil {
+		log.Error().Err(err).Msg("cadence script execution failed")
+		return
+	}
+
+	fmt.Printf("%s\n", value.String())
+
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/labstack/echo/v4 v4.3.0
 	github.com/onflow/cadence v0.16.1
 	github.com/onflow/flow-go v0.17.4
+	github.com/onflow/flow-go-sdk v0.20.0 // indirect
 	github.com/prometheus/client_golang v1.10.0 // indirect
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rs/zerolog v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -720,9 +720,12 @@ github.com/onflow/flow-go v0.17.4 h1:itgL/6xF08w4AULDvVj6qFo/37RBtcJBoYf6YcKI5Og
 github.com/onflow/flow-go v0.17.4/go.mod h1:HQ2m0XogkqW9BQeqoiDZdlpTdZldOkGVGvSn/oH0CnU=
 github.com/onflow/flow-go-sdk v0.20.0-alpha.1 h1:zy5viTpSQsfKgaoj9PgDOhoklLkG0Fze4okGFZ21Mus=
 github.com/onflow/flow-go-sdk v0.20.0-alpha.1/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
+github.com/onflow/flow-go-sdk v0.20.0 h1:0xcSC7OGO8DWZ7GWk/TUorVNcaPRfudH67RTzc782Kw=
+github.com/onflow/flow-go-sdk v0.20.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go/crypto v0.12.0 h1:TMsqn5nsW4vrCIFG/HRE/oy/a5/sffHrDRDYqicwO98=
 github.com/onflow/flow-go/crypto v0.12.0/go.mod h1:oXuvU0Dr4lHKgye6nHEFbBXIWNv+dBQUzoVW5Go38+o=
 github.com/onflow/flow/protobuf/go/flow v0.1.9/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
+github.com/onflow/flow/protobuf/go/flow v0.2.0 h1:a4Cg0ekoqb76zeOEo1wtSWtlnhGXwcxebp0itFwGtlE=
 github.com/onflow/flow/protobuf/go/flow v0.2.0/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
## Goal of this PR

This PR adds a command-line utility to execute Cadence scripts. It connects to an existing Flow network in a similar way as `flow-sim` - via the access nodes.

Script currently accepts a path to the external script file that should be executed, as well as a block height at which the script should be executed on.

At the moment, the height is internally treated as `int64`, not `uint64` (-1 being reserved for 'execute at latest height').

Example:
```console
$ ./execute-cadence-script -s get_balance.ca
100.00100004

$ ./execute-cadence-script -h 90 -s get_balance.ca
100.00100005

$ cat ./get_balance.ca
// This script reads the balance field of an account's FlowToken Balance

import FungibleToken from 0x9a0766d93b6608b7
import FlowToken from 0x7e60df042a9c0868

pub fun main(): UFix64 {

    // note that the account address is currently 
    // in the script itself, provided to the util
    var account: Address = 0x631e88ae7f1d7c20

        let vaultRef = getAccount(account)
        .getCapability(/public/flowTokenBalance)
        .borrow<&FlowToken.Vault{FungibleToken.Balance}>()
        ?? panic("Could not borrow Balance reference to the Vault")

        return vaultRef.balance
}
```

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date