### PR TITLE
Add GRPC API documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,7 @@ This document describes the internal components that the Flow Data Provisioning 
       3. [Invoker](#invoker)
       4. [Validator](#validator)
       5. [Retriever](#retriever)
+   2. [DPS API](#dps-api)
 
 ## Chain
 
@@ -193,3 +194,9 @@ It can be used to validate blocks, networks, accounts, transactions and currenci
 The retriever uses all the aforementioned components to retrieve account balances, blocks and transactions.
 
 [Package documentation](https://pkg.go.dev/github.com/optakt/flow-dps/rosetta/retriever)
+
+### DPS API
+
+The DPS API uses GRPC to allow clients to read from the DPS index.
+
+[API Documentation](dps-api.md)

--- a/docs/dps-api.md
+++ b/docs/dps-api.md
@@ -51,6 +51,16 @@
 
 The `data` field contains a [CBOR-encoded](https://cbor.io/) slice of Flow events (`[]flow.Event`) as payload.
 
+Here is an example of how to decode this field in a small Go program:
+
+```go
+   var events []flow.Event
+   err := cbor.Unmarshal(response.Data, &events)
+   if err != nil {
+     return err
+   }
+```
+
 | Field  | Type     | Label    |
 |--------|----------|----------|
 | height | `uint64` |          |
@@ -66,6 +76,16 @@ The `data` field contains a [CBOR-encoded](https://cbor.io/) slice of Flow event
 ### GetHeaderResponse
 
 The `data` field contains a [CBOR-encoded](https://cbor.io/) Flow header (`flow.Header`) as payload.
+
+Here is an example of how to decode this field in a small Go program:
+
+```go
+   var header flow.Header
+   err := cbor.Unmarshal(response.Data, &header)
+   if err != nil {
+     return err
+   }
+```
 
 | Field  | Type     | Label |
 |--------|----------|-------|

--- a/docs/dps-api.md
+++ b/docs/dps-api.md
@@ -49,6 +49,8 @@
 
 ### GetEventsResponse
 
+The `data` field contains [CBOR-encoded](https://cbor.io/) payloads.
+
 | Field  | Type     | Label    |
 |--------|----------|----------|
 | height | `uint64` |          |
@@ -62,6 +64,8 @@
 | height | `uint64` |       |
 
 ### GetHeaderResponse
+
+The `data` field contains [CBOR-encoded](https://cbor.io/) payloads.
 
 | Field  | Type     | Label |
 |--------|----------|-------|

--- a/docs/dps-api.md
+++ b/docs/dps-api.md
@@ -49,7 +49,7 @@
 
 ### GetEventsResponse
 
-The `data` field contains [CBOR-encoded](https://cbor.io/) payloads.
+The `data` field contains a [CBOR-encoded](https://cbor.io/) slice of Flow events (`[]flow.Event`) as payload.
 
 | Field  | Type     | Label    |
 |--------|----------|----------|
@@ -65,7 +65,7 @@ The `data` field contains [CBOR-encoded](https://cbor.io/) payloads.
 
 ### GetHeaderResponse
 
-The `data` field contains [CBOR-encoded](https://cbor.io/) payloads.
+The `data` field contains a [CBOR-encoded](https://cbor.io/) Flow header (`flow.Header`) as payload.
 
 | Field  | Type     | Label |
 |--------|----------|-------|

--- a/docs/dps-api.md
+++ b/docs/dps-api.md
@@ -1,0 +1,94 @@
+# DPS API Documentation
+
+## Table of Contents
+
+- [Endpoints](#Endpoints)
+- [Types](#Types)
+    - [GetCommitRequest](#GetCommitRequest)
+    - [GetCommitResponse](#GetCommitResponse)
+    - [GetEventsRequest](#GetEventsRequest)
+    - [GetEventsResponse](#GetEventsResponse)
+    - [GetHeaderRequest](#GetHeaderRequest)
+    - [GetHeaderResponse](#GetHeaderResponse)
+    - [GetLastRequest](#GetLastRequest)
+    - [GetLastResponse](#GetLastResponse)
+    - [GetRegistersRequest](#GetRegistersRequest)
+    - [GetRegistersResponse](#GetRegistersResponse)
+
+## Endpoints
+
+| Method Name  | Request Type                                | Response Type                                 |
+|--------------|---------------------------------------------|-----------------------------------------------|
+| GetLast      | [GetLastRequest](#GetLastRequest)           | [GetLastResponse](#GetLastResponse)           |
+| GetHeader    | [GetHeaderRequest](#GetHeaderRequest)       | [GetHeaderResponse](#GetHeaderResponse)       |
+| GetCommit    | [GetCommitRequest](#GetCommitRequest)       | [GetCommitResponse](#GetCommitResponse)       |
+| GetEvents    | [GetEventsRequest](#GetEventsRequest)       | [GetEventsResponse](#GetEventsResponse)       |
+| GetRegisters | [GetRegistersRequest](#GetRegistersRequest) | [GetRegistersResponse](#GetRegistersResponse) |
+
+## Types
+
+### GetCommitRequest
+
+| Field  | Type     | Label |
+|--------|----------|-------|
+| height | `uint64` |       |
+
+### GetCommitResponse
+
+| Field  | Type     | Label |
+|--------|----------|-------|
+| height | `uint64` |       |
+| commit | `bytes`  |       |
+
+### GetEventsRequest
+
+| Field  | Type     | Label    |
+|--------|----------|----------|
+| height | `uint64` |          |
+| types  | `string` | repeated |
+
+### GetEventsResponse
+
+| Field  | Type     | Label    |
+|--------|----------|----------|
+| height | `uint64` |          |
+| types  | `string` | repeated |
+| data   | `bytes`  |          |
+
+### GetHeaderRequest
+
+| Field  | Type     | Label |
+|--------|----------|-------|
+| height | `uint64` |       |
+
+### GetHeaderResponse
+
+| Field  | Type     | Label |
+|--------|----------|-------|
+| height | `uint64` |       |
+| data   | `bytes`  |       |
+
+### GetLastRequest
+
+For now, `GetLastRequest` is empty.
+
+### GetLastResponse
+
+| Field  | Type     | Label |
+|--------|----------|-------|
+| height | `uint64` |       |
+
+### GetRegistersRequest
+
+| Field  | Type     | Label    |
+|--------|----------|----------|
+| height | `uint64` |          |
+| paths  | `bytes`  | repeated |
+
+### GetRegistersResponse
+
+| Field  | Type     | Label    |
+|--------|----------|----------|
+| height | `uint64` |          |
+| paths  | `bytes`  | repeated |
+| values | `bytes`  | repeated |


### PR DESCRIPTION
## Goal of this PR

This PR fixes #131. It adds a documentation file that was mostly generated using `pseudomuto/protoc-gen-doc` and then manually tweaked. This approach might allow us to automatically generate the documentation and maintain it up-to-date without any human intervention in the future. We just need to find a way to automate the tweaking once it's worth the trouble compared to the maintenance costs in time.

## Tools used

* [pseudomuto/protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc) for transforming the Protobuf file into a markdown documentation file
* [markdowntable.com](http://markdowntable.com/) for markdown table re-formatting

```bash
# Generate documentation file
docker run --rm \
      -v $PWD/docs:/out \
      -v $PWD/api/grpc:/protos \
      pseudomuto/protoc-gen-doc --doc_opt=markdown,grpc-api.md
```

One slight inconvenience is that it does not support the `optional` keyword since it was made deprecated, so I had to remove it from the protobuf file before generating and put it back afterwards, as well as manually add it to the `labels` columns in the generated docs.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [ ] ~Tests are up-to-date~