### PR TITLE
Switch to CBOR with string timestamp encoding

### DIFF
--- a/api/dps/server.go
+++ b/api/dps/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 
 	"github.com/optakt/flow-dps/models/convert"
+	"github.com/optakt/flow-dps/models/dps"
 	"github.com/optakt/flow-dps/models/index"
 )
 
@@ -39,7 +40,7 @@ type Server struct {
 // for data retrieval.
 func NewServer(index index.Reader) *Server {
 
-	codec, _ := cbor.CanonicalEncOptions().EncMode()
+	codec, _ := dps.Encoding.EncMode()
 
 	s := Server{
 		index: index,

--- a/api/dps/server_test.go
+++ b/api/dps/server_test.go
@@ -19,12 +19,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/optakt/flow-dps/models/convert"
+	"github.com/optakt/flow-dps/models/dps"
 	"github.com/optakt/flow-dps/testing/mocks"
 )
 
@@ -167,7 +167,7 @@ func TestServerGetLast(t *testing.T) {
 func TestServerGetHeader(t *testing.T) {
 
 	var (
-		testCodec, _ = cbor.CanonicalEncOptions().EncMode()
+		testCodec, _ = dps.Encoding.EncMode()
 		testHeight   = uint64(128)
 		testHeader   = flow.Header{Height: testHeight}
 		testData, _  = testCodec.Marshal(testHeader)
@@ -330,7 +330,7 @@ func TestServerGetCommit(t *testing.T) {
 func TestServerGetEvents(t *testing.T) {
 
 	var (
-		testCodec, _ = cbor.CanonicalEncOptions().EncMode()
+		testCodec, _ = dps.Encoding.EncMode()
 		testHeight   = uint64(128)
 		testEvents   = []flow.Event{
 			{TransactionID: flow.Identifier{0x1, 0x2}},

--- a/cmd/extract-block-events/main.go
+++ b/cmd/extract-block-events/main.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 
@@ -87,7 +86,7 @@ func run() int {
 	defer db.Close()
 
 	// Initialize the codec we use for the data.
-	codec, _ := cbor.CanonicalEncOptions().EncMode()
+	codec, _ := dps.Encoding.EncMode()
 
 	// Make a list of all available heights and shuffle them.
 	if flagBegin > flagFinish {

--- a/cmd/extract-block-headers/main.go
+++ b/cmd/extract-block-headers/main.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 
@@ -85,7 +84,7 @@ func run() int {
 	defer db.Close()
 
 	// Initialize the codec we use for the data.
-	codec, _ := cbor.CanonicalEncOptions().EncMode()
+	codec, _ := dps.Encoding.EncMode()
 
 	// Make a list of all available heights and shuffle them.
 	if flagBegin > flagFinish {

--- a/cmd/extract-ledger-payloads/main.go
+++ b/cmd/extract-ledger-payloads/main.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/prometheus/tsdb/wal"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
@@ -129,7 +128,7 @@ func run() int {
 
 	// Now, we got the full trie and we can write random payloads to disk until
 	// we have enough data for the dictionary creator.
-	codec, _ := cbor.CanonicalEncOptions().EncMode()
+	codec, _ := dps.Encoding.EncMode()
 	payloads := tree.AllPayloads()
 	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(payloads), func(i int, j int) {

--- a/models/dps/encoding.go
+++ b/models/dps/encoding.go
@@ -14,7 +14,9 @@
 
 package dps
 
-import "github.com/fxamacker/cbor/v2"
+import (
+	"github.com/fxamacker/cbor/v2"
+)
 
 var Encoding = cbor.CanonicalEncOptions()
 

--- a/models/dps/encoding.go
+++ b/models/dps/encoding.go
@@ -1,0 +1,23 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package dps
+
+import "github.com/fxamacker/cbor/v2"
+
+var Encoding = cbor.CanonicalEncOptions()
+
+func init() {
+	Encoding.Time = cbor.TimeRFC3339Nano
+}

--- a/service/storage/encoding.go
+++ b/service/storage/encoding.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
 
+	"github.com/optakt/flow-dps/models/dps"
 	"github.com/optakt/flow-dps/service/dictionaries"
 )
 
@@ -45,7 +46,7 @@ var (
 func init() {
 	var err error
 
-	codec, _ = cbor.CanonicalEncOptions().EncMode()
+	codec, _ = dps.Encoding.EncMode()
 
 	defaultCompressor, err = zstd.NewWriter(nil,
 		zstd.WithEncoderLevel(zstd.SpeedDefault),


### PR DESCRIPTION
## Goal of this PR

This PR makes sure that we lose neither sub-second precision, nor time zone information, for CBOR encoded timestamps. This means that the block ID for headers retrieved from the index should stay correct.

Fixes #139.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date