### PR TITLE
remove validation from rosetta API

### DIFF
--- a/api/rosetta/balance.go
+++ b/api/rosetta/balance.go
@@ -45,25 +45,6 @@ func (d *Data) Balance(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, object.AnyError(err))
 	}
 
-	err = d.validate.Network(req.NetworkID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnprocessableEntity, object.AnyError(err))
-	}
-	err = d.validate.Block(req.BlockID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnprocessableEntity, object.AnyError(err))
-	}
-	err = d.validate.Account(req.AccountID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnprocessableEntity, object.AnyError(err))
-	}
-	for _, currency := range req.Currencies {
-		err = d.validate.Currency(currency)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusUnprocessableEntity, object.AnyError(err))
-		}
-	}
-
 	balances, err := d.retrieve.Balances(req.NetworkID, req.BlockID, req.AccountID, req.Currencies)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, object.AnyError(err))

--- a/api/rosetta/block.go
+++ b/api/rosetta/block.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/optakt/flow-dps/rosetta/identifier"
 	"github.com/optakt/flow-dps/rosetta/object"
+	"github.com/optakt/flow-dps/rosetta/resource"
 )
 
 type BlockRequest struct {
@@ -29,7 +30,7 @@ type BlockRequest struct {
 }
 
 type BlockResponse struct {
-	Block             *object.Block            `json:"block"`
+	Block             *resource.Block          `json:"block"`
 	OtherTransactions []identifier.Transaction `json:"other_transactions"`
 }
 
@@ -43,23 +44,14 @@ func (d *Data) Block(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, object.AnyError(err))
 	}
 
-	err = d.validate.Network(req.NetworkID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnprocessableEntity, object.AnyError(err))
-	}
-	err = d.validate.Block(req.BlockID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnprocessableEntity, object.AnyError(err))
-	}
-
-	block, transactions, err := d.retrieve.Block(req.NetworkID, req.BlockID)
+	block, other, err := d.retrieve.Block(req.NetworkID, req.BlockID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, object.AnyError(err))
 	}
 
 	res := BlockResponse{
 		Block:             block,
-		OtherTransactions: transactions,
+		OtherTransactions: other,
 	}
 
 	return ctx.JSON(http.StatusOK, res)

--- a/api/rosetta/configuration.go
+++ b/api/rosetta/configuration.go
@@ -16,12 +16,13 @@ package rosetta
 
 import (
 	"github.com/optakt/flow-dps/rosetta/identifier"
+	"github.com/optakt/flow-dps/rosetta/object"
 )
 
-type Validator interface {
-	Network(network identifier.Network) error
-	Block(block identifier.Block) error
-	Transaction(transaction identifier.Transaction) error
-	Account(account identifier.Account) error
-	Currency(currency identifier.Currency) error
+type Configuration interface {
+	Network() identifier.Network
+	Version() object.Version
+	Operations() []string
+	Statuses() []object.StatusDefinition
+	Errors() []object.ErrorDefinition
 }

--- a/api/rosetta/data.go
+++ b/api/rosetta/data.go
@@ -15,13 +15,12 @@
 package rosetta
 
 type Data struct {
-	validate Validator
+	config   Configuration
 	retrieve Retriever
 }
 
-func NewData(validate Validator, retrieve Retriever) *Data {
+func NewData(config Configuration, retrieve Retriever) *Data {
 	d := Data{
-		validate: validate,
 		retrieve: retrieve,
 	}
 	return &d

--- a/api/rosetta/networks.go
+++ b/api/rosetta/networks.go
@@ -39,14 +39,9 @@ func (d *Data) Networks(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, object.AnyError(err))
 	}
 
-	// For now, we simply return a single network, which is the main chain of
-	// the Flow blockchain network.
-	network, err := d.retrieve.Network()
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
-	}
+	// Get the network we are running on from the configuration.
 	res := NetworksResponse{
-		NetworkIDs: []identifier.Network{network},
+		NetworkIDs: []identifier.Network{d.config.Network()},
 	}
 
 	return ctx.JSON(http.StatusOK, res)

--- a/api/rosetta/status.go
+++ b/api/rosetta/status.go
@@ -41,12 +41,6 @@ func (d *Data) Status(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 
-	// Get our network and check it's correct.
-	err = d.validate.Network(req.NetworkID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnprocessableEntity, object.AnyError(err))
-	}
-
 	oldest, _, err := d.retrieve.Oldest()
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, object.AnyError(err))

--- a/api/rosetta/transaction.go
+++ b/api/rosetta/transaction.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/optakt/flow-dps/rosetta/identifier"
 	"github.com/optakt/flow-dps/rosetta/object"
+	"github.com/optakt/flow-dps/rosetta/resource"
 )
 
 type TransactionRequest struct {
@@ -30,7 +31,7 @@ type TransactionRequest struct {
 }
 
 type TransactionResponse struct {
-	Transaction *object.Transaction `json:"transaction"`
+	Transaction *resource.Transaction `json:"transaction"`
 }
 
 // TODO: integration testing of Rosetta transaction endpoint
@@ -41,19 +42,6 @@ func (d *Data) Transaction(ctx echo.Context) error {
 	err := ctx.Bind(&req)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, object.AnyError(err))
-	}
-
-	err = d.validate.Network(req.NetworkID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnprocessableEntity, object.AnyError(err))
-	}
-	err = d.validate.Block(req.BlockID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnprocessableEntity, object.AnyError(err))
-	}
-	err = d.validate.Transaction(req.TransactionID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusUnprocessableEntity, object.AnyError(err))
 	}
 
 	transaction, err := d.retrieve.Transaction(req.NetworkID, req.BlockID, req.TransactionID)

--- a/cmd/flow-rosetta-server/main.go
+++ b/cmd/flow-rosetta-server/main.go
@@ -34,10 +34,10 @@ import (
 	api "github.com/optakt/flow-dps/api/dps"
 	"github.com/optakt/flow-dps/api/rosetta"
 	"github.com/optakt/flow-dps/models/dps"
+	"github.com/optakt/flow-dps/rosetta/configuration"
 	"github.com/optakt/flow-dps/rosetta/invoker"
 	"github.com/optakt/flow-dps/rosetta/retriever"
 	"github.com/optakt/flow-dps/rosetta/scripts"
-	"github.com/optakt/flow-dps/rosetta/validator"
 )
 
 const (
@@ -98,11 +98,11 @@ func run() int {
 	// Rosetta API initialization.
 	client := api.NewAPIClient(conn)
 	index := api.IndexFromAPI(client)
+	config := configuration.New(params.ChainID)
 	generator := scripts.NewGenerator(params)
 	invoke := invoker.New(index)
-	validate := validator.New(params)
 	retrieve := retriever.New(params, index, generator, invoke)
-	ctrl := rosetta.NewData(validate, retrieve)
+	ctrl := rosetta.NewData(config, retrieve)
 
 	// TODO: Implement custom echo logger middleware that wraps around our own
 	// zerolog instance:

--- a/rosetta/configuration/configuration.go
+++ b/rosetta/configuration/configuration.go
@@ -1,0 +1,91 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package configuration
+
+import (
+	"github.com/onflow/flow-go/model/flow"
+
+	"github.com/optakt/flow-dps/models/dps"
+	"github.com/optakt/flow-dps/rosetta/identifier"
+	"github.com/optakt/flow-dps/rosetta/object"
+)
+
+type Configuration struct {
+	network    identifier.Network
+	version    object.Version
+	statuses   []object.StatusDefinition
+	operations []string
+	errors     []object.ErrorDefinition
+}
+
+func New(chain flow.ChainID) *Configuration {
+
+	network := identifier.Network{
+		Blockchain: dps.FlowBlockchain,
+		Network:    chain.String(),
+	}
+
+	// TODO: Find a way to inject the Flow Go dependency version from the
+	// `go.mod` file and the middleware version from the repository tag:
+	// => https://github.com/optakt/flow-dps/issues/151
+
+	version := object.Version{
+		RosettaVersion:    "1.4.10",
+		NodeVersion:       "1.17.4",
+		MiddlewareVersion: "0.0.0",
+	}
+
+	statuses := []object.StatusDefinition{
+		{Status: "COMPLETED", Successful: true},
+	}
+
+	operations := []string{
+		"TRANSFER",
+	}
+
+	errors := []object.ErrorDefinition{
+		{Code: object.AnyCode, Message: object.AnyMessage, Retriable: object.AnyRetriable},
+	}
+
+	c := Configuration{
+		network:    network,
+		version:    version,
+		statuses:   statuses,
+		operations: operations,
+		errors:     errors,
+	}
+
+	return &c
+}
+
+func (c *Configuration) Network() identifier.Network {
+	return c.network
+}
+
+func (c *Configuration) Version() object.Version {
+	return c.version
+}
+
+func (c *Configuration) Statuses() []object.StatusDefinition {
+	return c.statuses
+}
+
+func (c *Configuration) Operations() []string {
+	return c.operations
+}
+
+func (c *Configuration) Errors() []object.ErrorDefinition {
+	return c.errors
+}

--- a/rosetta/object/error.go
+++ b/rosetta/object/error.go
@@ -22,19 +22,27 @@ package object
 // Example for detail fields given in the Rosetta API documentation are
 // `address` and `error`.
 type Error struct {
-	Code        uint                   `json:"code"`
-	Message     string                 `json:"message"`
+	ErrorDefinition
 	Description string                 `json:"description"`
-	Retriable   bool                   `json:"retriable"`
 	Details     map[string]interface{} `json:"details"`
 }
 
+const (
+	AnyCode = 1
+
+	AnyMessage = "catch-all for all errors for now"
+
+	AnyRetriable = false
+)
+
 func AnyError(err error) Error {
 	return Error{
-		Code:        1,
-		Message:     "catch-all for all errors for now",
+		ErrorDefinition: ErrorDefinition{
+			Code:      AnyCode,
+			Message:   AnyMessage,
+			Retriable: AnyRetriable,
+		},
 		Description: err.Error(),
-		Retriable:   false,
 		Details:     make(map[string]interface{}),
 	}
 }

--- a/rosetta/object/error_definition.go
+++ b/rosetta/object/error_definition.go
@@ -14,8 +14,8 @@
 
 package object
 
-type Version struct {
-	RosettaVersion    string `json:"rosetta_version"`
-	NodeVersion       string `json:"node_version"`
-	MiddlewareVersion string `json:"middleware_version"`
+type ErrorDefinition struct {
+	Code      uint   `json:"code"`
+	Message   string `json:"message"`
+	Retriable bool   `json:"retriable"`
 }

--- a/rosetta/object/operation_definition.go
+++ b/rosetta/object/operation_definition.go
@@ -14,16 +14,7 @@
 
 package object
 
-import (
-	"github.com/optakt/flow-dps/rosetta/identifier"
-)
-
-// Transaction contains an array of operations that are attributable to the same
-// transaction identifier.
-//
-// Examples of metadata given in the Rosetta API documentation are "size" and
-// "lockTime".
-type Transaction struct {
-	ID         identifier.Transaction `json:"transaction_identifier"`
-	Operations []Operation            `json:"operations"`
+type StatusDefinition struct {
+	Status     string `json:"status"`
+	Successful bool   `json:"successful"`
 }

--- a/rosetta/object/version.go
+++ b/rosetta/object/version.go
@@ -14,14 +14,8 @@
 
 package object
 
-type Allow struct {
-	OperationStatuses       []OperationStatus `json:"operation_statuses"`
-	OperationTypes          []string          `json:"operation_types"`
-	Errors                  []Error           `json:"errors"`
-	HistoricalBalanceLookup bool              `json:"historical_balance_lookup"`
-}
-
-type OperationStatus struct {
-	Status     string `json:"status"`
-	Successful bool   `json:"successful"`
+type Version struct {
+	RosettaVersion    string `json:"rosetta_version"`
+	NodeVersion       string `json:"node_version"`
+	MiddlewareVersion string `json:"middleware_version"`
 }

--- a/rosetta/resource/block.go
+++ b/rosetta/resource/block.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package object
+package resource
 
 import (
 	"github.com/optakt/flow-dps/rosetta/identifier"

--- a/rosetta/resource/operation.go
+++ b/rosetta/resource/operation.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package object
+package resource
 
 import (
 	"github.com/optakt/flow-dps/rosetta/identifier"
@@ -36,5 +36,5 @@ type Operation struct {
 	Type       string                 `json:"type"`
 	Status     string                 `json:"status"`
 	AccountID  identifier.Account     `json:"account"`
-	Amount     Amount                 `json:"amount"`
+	Amount     object.Amount          `json:"amount"`
 }

--- a/rosetta/resource/transaction.go
+++ b/rosetta/resource/transaction.go
@@ -12,20 +12,18 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package rosetta
+package resource
 
 import (
-	"time"
-
 	"github.com/optakt/flow-dps/rosetta/identifier"
-	"github.com/optakt/flow-dps/rosetta/object"
-	"github.com/optakt/flow-dps/rosetta/resource"
 )
 
-type Retriever interface {
-	Oldest() (identifier.Block, time.Time, error)
-	Current() (identifier.Block, time.Time, error)
-	Block(network identifier.Network, block identifier.Block) (*resource.Block, []identifier.Transaction, error)
-	Transaction(network identifier.Network, block identifier.Block, transaction identifier.Transaction) (*resource.Transaction, error)
-	Balances(network identifier.Network, block identifier.Block, account identifier.Account, currencies []identifier.Currency) ([]object.Amount, error)
+// Transaction contains an array of operations that are attributable to the same
+// transaction identifier.
+//
+// Examples of metadata given in the Rosetta API documentation are "size" and
+// "lockTime".
+type Transaction struct {
+	ID         identifier.Transaction `json:"transaction_identifier"`
+	Operations []*Operation           `json:"operations"`
 }


### PR DESCRIPTION
## Goal of this PR

This PR improves the boundaries of the packages related to the Rosetta API. When it comes to models, we have three different types:

- types representing identifiers, which are in the `identifier` package;
- types representing blockchain resources, which are now in the `resource` package; and
- types representing configuration information or value types, which are now in the `object` package.

We also remove semantic validation from the Rosetta API package and will add it back as part of the Rosetta business logic. The API code should just code/decode and ensure that we have the correct format. It should not know anything about the chain state.