### PR TITLE
Add storage package unit tests

### DIFF
--- a/service/chain/disk_test.go
+++ b/service/chain/disk_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage/badger/operation"
+	"github.com/optakt/flow-dps/testing/helpers"
 
 	"github.com/optakt/flow-dps/service/chain"
 )
@@ -90,17 +91,10 @@ func TestDisk_Events(t *testing.T) {
 }
 
 func inMemoryDB(t *testing.T) *badger.DB {
-	t.Helper()
+	db := helpers.InMemoryDB(t)
 
-	opts := badger.DefaultOptions("")
-	opts.InMemory = true
-	opts.Logger = nil
-
-	db, err := badger.Open(opts)
-	require.NoError(t, err)
-
-	err = db.Update(func(tx *badger.Txn) error {
-		err = operation.InsertRootHeight(testHeight)(tx)
+	err := db.Update(func(tx *badger.Txn) error {
+		err := operation.InsertRootHeight(testHeight)(tx)
 		if err != nil {
 			return err
 		}

--- a/service/chain/disk_test.go
+++ b/service/chain/disk_test.go
@@ -91,6 +91,8 @@ func TestDisk_Events(t *testing.T) {
 }
 
 func inMemoryDB(t *testing.T) *badger.DB {
+	t.Helper()
+
 	db := helpers.InMemoryDB(t)
 
 	err := db.Update(func(tx *badger.Txn) error {

--- a/service/chain/disk_test.go
+++ b/service/chain/disk_test.go
@@ -40,7 +40,7 @@ var (
 )
 
 func TestDisk_Root(t *testing.T) {
-	db := inMemoryDB(t)
+	db := populatedDB(t)
 	defer db.Close()
 	c := chain.FromDisk(db)
 
@@ -50,7 +50,7 @@ func TestDisk_Root(t *testing.T) {
 }
 
 func TestDisk_Header(t *testing.T) {
-	db := inMemoryDB(t)
+	db := populatedDB(t)
 	defer db.Close()
 	c := chain.FromDisk(db)
 
@@ -65,7 +65,7 @@ func TestDisk_Header(t *testing.T) {
 }
 
 func TestDisk_Commit(t *testing.T) {
-	db := inMemoryDB(t)
+	db := populatedDB(t)
 	defer db.Close()
 	c := chain.FromDisk(db)
 
@@ -78,7 +78,7 @@ func TestDisk_Commit(t *testing.T) {
 }
 
 func TestDisk_Events(t *testing.T) {
-	db := inMemoryDB(t)
+	db := populatedDB(t)
 	defer db.Close()
 	c := chain.FromDisk(db)
 
@@ -90,7 +90,7 @@ func TestDisk_Events(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func inMemoryDB(t *testing.T) *badger.DB {
+func populatedDB(t *testing.T) *badger.DB {
 	t.Helper()
 
 	db := helpers.InMemoryDB(t)

--- a/service/index/writer.go
+++ b/service/index/writer.go
@@ -60,7 +60,7 @@ func (w *Writer) Header(height uint64, header *flow.Header) error {
 // Commit indexes the given commitment of the execution state as it was after
 // the execution of the finalized block at the given height.
 func (w *Writer) Commit(height uint64, commit flow.StateCommitment) error {
-	return w.db.Update(storage.SaveCommit(commit, height))
+	return w.db.Update(storage.SaveCommit(height, commit))
 }
 
 // Events indexes the events, which should represent all events of the finalized

--- a/service/storage/auxiliary.go
+++ b/service/storage/auxiliary.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dgraph-io/badger/v2"
 	"github.com/fxamacker/cbor/v2"
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/service/storage/auxiliary_test.go
+++ b/service/storage/auxiliary_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
+
 	"github.com/optakt/flow-dps/testing/helpers"
 )
 

--- a/service/storage/auxiliary_test.go
+++ b/service/storage/auxiliary_test.go
@@ -1,0 +1,298 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package storage
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/optakt/flow-dps/testing/helpers"
+)
+
+func TestFallback(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+	txn := db.NewTransaction(false)
+
+	// This is a success func that is never expected to be called.
+	noCallFn := func(txn *badger.Txn) error {
+		t.Fail()
+		return nil
+	}
+	successFn := func(txn *badger.Txn) error {
+		return nil
+	}
+	failFn := func(txn *badger.Txn) error {
+		return errors.New("fail")
+	}
+
+	t.Run("should error if all ops failed", func(t *testing.T) {
+		err := Fallback(
+			failFn,
+			failFn,
+			failFn,
+			failFn,
+		)(txn)
+
+		assert.Error(t, err)
+		merr, ok := err.(*multierror.Error)
+		assert.True(t, ok)
+		assert.Len(t, merr.Errors, 4)
+	})
+
+	t.Run("should not error if fallback succeeds", func(t *testing.T) {
+		err := Fallback(
+			failFn,
+			successFn,
+			noCallFn,
+			noCallFn,
+		)(txn)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("should not error if any fallback succeeds", func(t *testing.T) {
+		err := Fallback(
+			failFn,
+			failFn,
+			failFn,
+			failFn,
+			failFn,
+			successFn,
+			noCallFn,
+			noCallFn,
+			noCallFn,
+		)(txn)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("should not call second fallback op if first fallback succeeds", func(t *testing.T) {
+		err := Fallback(
+			failFn,
+			failFn,
+			failFn,
+			successFn,
+			noCallFn,
+			noCallFn,
+			noCallFn,
+		)(txn)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("should not call fallback if first op succeeds", func(t *testing.T) {
+		err := Fallback(
+			successFn,
+			noCallFn,
+			noCallFn,
+			noCallFn,
+			noCallFn,
+		)(txn)
+
+		assert.NoError(t, err)
+	})
+}
+
+func TestCombine(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+	txn := db.NewTransaction(false)
+
+	// This is a success func that is never expected to be called.
+	noCallFn := func(txn *badger.Txn) error {
+		t.Fail()
+		return nil
+	}
+	successFn := func(txn *badger.Txn) error {
+		return nil
+	}
+	failFn := func(txn *badger.Txn) error {
+		return errors.New("fail")
+	}
+
+	t.Run("nominal case", func(t *testing.T) {
+		calls := 0
+		f := func(txn *badger.Txn) error {
+			calls++
+			return nil
+		}
+		err := Combine(f, f, f, f, f, f)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, calls, 6)
+	})
+
+	t.Run("should error if first op fails", func(t *testing.T) {
+		err := Combine(
+			failFn,
+			noCallFn,
+			noCallFn,
+			noCallFn,
+		)(txn)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("should error if last op fails", func(t *testing.T) {
+		err := Combine(
+			successFn,
+			failFn,
+		)(txn)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("should error if any op fails", func(t *testing.T) {
+		err := Combine(
+			successFn,
+			successFn,
+			successFn,
+			successFn,
+			failFn,
+			noCallFn,
+			noCallFn,
+		)(txn)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestRetrieve(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+
+	// Insert test value.
+	const testValue = uint64(42)
+	testKey := []byte{42}
+
+	t.Run("nominal case", func(t *testing.T) {
+		insertKeyValue(t, db, testKey, testValue)
+		txn := db.NewTransaction(false)
+
+		var got uint64
+		err := retrieve(testKey, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, got, testValue)
+	})
+
+	t.Run("unknown key, should fail", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got uint64
+		err := retrieve([]byte{13, 37}, &got)(txn)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("badly encoded value, should fail", func(t *testing.T) {
+		insertUnencodedKeyValue(t, db, testKey, testValue)
+		txn := db.NewTransaction(false)
+
+		var got uint64
+		err := retrieve(testKey, &got)(txn)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestSave(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+
+	t.Run("nominal case", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+		err := save([]byte{13, 37}, uint64(42))(txn)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("saving a nil value should work", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+		err := save([]byte{13, 37}, nil)(txn)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("saving a flow header value should use the headerCompressor", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+		err := save([]byte{13, 37}, &flow.Header{})(txn)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("saving a ledger payload value should use the payloadCompressor", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+		err := save([]byte{13, 37}, &ledger.Payload{})(txn)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("saving a flow event slice value should use the eventsCompressor", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+		err := save([]byte{13, 37}, []flow.Event{})(txn)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("saving a value at an empty key should fail", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+		err := save([]byte{}, uint64(42))(txn)
+
+		assert.Error(t, err)
+	})
+}
+
+func insertKeyValue(t *testing.T, db *badger.DB, key []byte, value uint64) {
+	t.Helper()
+
+	err := db.Update(func(txn *badger.Txn) error {
+		val, err := codec.Marshal(value)
+		if err != nil {
+			return fmt.Errorf("unable to encode value: %w", err)
+		}
+
+		val = defaultCompressor.EncodeAll(val, nil)
+
+		err = txn.Set(key, val)
+		require.NoError(t, err)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func insertUnencodedKeyValue(t *testing.T, db *badger.DB, key []byte, value uint64) {
+	t.Helper()
+
+	err := db.Update(func(txn *badger.Txn) error {
+		val := make([]byte, 8)
+		binary.BigEndian.PutUint64(val, value)
+
+		err := txn.Set(key, val)
+		require.NoError(t, err)
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/service/storage/encoding_test.go
+++ b/service/storage/encoding_test.go
@@ -1,0 +1,97 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestEncodeKey(t *testing.T) {
+	id, _ := flow.HexStringToIdentifier("aac513eb1a0457700ac3fa8d292513e18ad7fd70065146b35ab48fa5a6cab007")
+	path, _ := ledger.ToPath([]byte("aac513eb1a0457700ac3fa8d292513e1"))
+	commit, _ := flow.ToStateCommitment([]byte("07018030187ecf04945f35f1e33a89dc"))
+
+	tests := []struct {
+		description string
+
+		segments []interface{}
+
+		wantKey   []byte
+		wantPanic bool
+	}{
+		{
+			description: "a key with all types combined should work",
+
+			segments: []interface{}{
+				uint64(42),
+				id,
+				path,
+				commit,
+			},
+
+			wantPanic: false,
+			wantKey: []byte{
+				0x1,                                     // Prefix
+				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2a, // uint(42)
+				0xaa, 0xc5, 0x13, 0xeb, 0x1a, 0x4, 0x57, 0x70, 0xa, 0xc3, 0xfa, 0x8d, 0x29, 0x25, 0x13, 0xe1, 0x8a, 0xd7, 0xfd, 0x70, 0x6, 0x51, 0x46, 0xb3, 0x5a, 0xb4, 0x8f, 0xa5, 0xa6, 0xca, 0xb0, 0x7, // id
+				0x61, 0x61, 0x63, 0x35, 0x31, 0x33, 0x65, 0x62, 0x31, 0x61, 0x30, 0x34, 0x35, 0x37, 0x37, 0x30, 0x30, 0x61, 0x63, 0x33, 0x66, 0x61, 0x38, 0x64, 0x32, 0x39, 0x32, 0x35, 0x31, 0x33, 0x65, 0x31, // path
+				0x30, 0x37, 0x30, 0x31, 0x38, 0x30, 0x33, 0x30, 0x31, 0x38, 0x37, 0x65, 0x63, 0x66, 0x30, 0x34, 0x39, 0x34, 0x35, 0x66, 0x33, 0x35, 0x66, 0x31, 0x65, 0x33, 0x33, 0x61, 0x38, 0x39, 0x64, 0x63, // commit
+			},
+		},
+		{
+			description: "empty segments should work",
+
+			wantPanic: false,
+			wantKey:   []byte{1},
+		},
+		{
+			description: "unsupported types should panic",
+
+			segments: []interface{}{
+				uint16(42),
+				&flow.Header{},
+				&ledger.Payload{},
+			},
+
+			wantPanic: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
+
+			if test.wantPanic {
+				assert.Panics(t, func() {
+					encodeKey(1, test.segments...)
+				})
+				return
+			}
+
+			var got []byte
+			assert.NotPanics(t, func() {
+				got = encodeKey(1, test.segments...)
+			})
+
+			assert.Equal(t, test.wantKey, got)
+		})
+	}
+}

--- a/service/storage/encoding_test.go
+++ b/service/storage/encoding_test.go
@@ -65,9 +65,7 @@ func TestEncodeKey(t *testing.T) {
 			description: "unsupported types should panic",
 
 			segments: []interface{}{
-				uint16(42),
-				&flow.Header{},
-				&ledger.Payload{},
+				struct{}{},
 			},
 
 			wantPanic: true,

--- a/service/storage/operations.go
+++ b/service/storage/operations.go
@@ -35,7 +35,7 @@ func SaveLast(height uint64) func(*badger.Txn) error {
 	return save(encodeKey(prefixLast), height)
 }
 
-func SaveCommit(commit flow.StateCommitment, height uint64) func(*badger.Txn) error {
+func SaveCommit(height uint64, commit flow.StateCommitment) func(*badger.Txn) error {
 	return save(encodeKey(prefixCommit, height), commit)
 }
 

--- a/service/storage/operations_test.go
+++ b/service/storage/operations_test.go
@@ -262,16 +262,6 @@ func TestSaveAndRetrieve_Payload(t *testing.T) {
 		assert.Equal(t, *payload1, got)
 	})
 
-	t.Run("retrieve payload before it was ever indexed", func(t *testing.T) {
-		txn := db.NewTransaction(false)
-
-		var got ledger.Payload
-		err := RetrievePayload(63, path, &got)(txn)
-
-		assert.NoError(t, err)
-		assert.Equal(t, *payload1, got)
-	})
-
 	t.Run("retrieve payload after last indexed", func(t *testing.T) {
 		txn := db.NewTransaction(false)
 
@@ -280,6 +270,15 @@ func TestSaveAndRetrieve_Payload(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, *payload2, got)
+	})
+
+	t.Run("retrieve payload before it was ever indexed", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got ledger.Payload
+		err := RetrievePayload(10, path, &got)(txn)
+
+		assert.Error(t, err)
 	})
 
 	t.Run("should fail if path does not match", func(t *testing.T) {

--- a/service/storage/operations_test.go
+++ b/service/storage/operations_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
+
 	"github.com/optakt/flow-dps/testing/helpers"
 )
 

--- a/service/storage/operations_test.go
+++ b/service/storage/operations_test.go
@@ -1,0 +1,311 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/optakt/flow-dps/testing/helpers"
+)
+
+func TestSaveAndRetrieve_First(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+
+	t.Run("save first height", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+		err := SaveFirst(42)(txn)
+
+		assert.NoError(t, err)
+
+		err = txn.Commit()
+		require.NoError(t, err)
+	})
+
+	t.Run("retrieve first height", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got uint64
+		err := RetrieveFirst(&got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(42), got)
+	})
+}
+
+func TestSaveAndRetrieve_Last(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+
+	t.Run("save last height", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+
+		err := SaveLast(42)(txn)
+
+		assert.NoError(t, err)
+
+		err = txn.Commit()
+		require.NoError(t, err)
+	})
+
+	t.Run("retrieve last height", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got uint64
+		err := RetrieveLast(&got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(42), got)
+	})
+}
+
+func TestSaveAndRetrieve_Commit(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+
+	commit, _ := flow.ToStateCommitment([]byte("07018030187ecf04945f35f1e33a89dc"))
+
+	t.Run("save commit", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+
+		err := SaveCommit(42, commit)(txn)
+
+		assert.NoError(t, err)
+
+		err = txn.Commit()
+		require.NoError(t, err)
+	})
+
+	t.Run("retrieve commit", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got flow.StateCommitment
+		err := RetrieveCommit(42, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, commit, got)
+	})
+}
+
+func TestSaveAndRetrieve_Header(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+
+	header := &flow.Header{ChainID: "flow-testnet"}
+
+	t.Run("save header", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+
+		err := SaveHeader(42, header)(txn)
+
+		assert.NoError(t, err)
+
+		err = txn.Commit()
+		require.NoError(t, err)
+	})
+
+	t.Run("retrieve header", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got flow.Header
+		err := RetrieveHeader(42, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *header, got)
+	})
+}
+
+func TestSaveAndRetrieve_Events(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+
+	testTyp1 := flow.EventType("test1")
+	testEvents1 := []flow.Event{{Type: testTyp1}, {Type: testTyp1}, {Type: testTyp1}}
+	testTyp2 := flow.EventType("test2")
+	testEvents2 := []flow.Event{{Type: testTyp2}, {Type: testTyp2}, {Type: testTyp2}}
+
+	t.Run("save multiple events under different types", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+
+		err := SaveEvents(42, testTyp1, testEvents1)(txn)
+
+		assert.NoError(t, err)
+
+		err = SaveEvents(42, testTyp2, testEvents2)(txn)
+
+		assert.NoError(t, err)
+
+		err = txn.Commit()
+		require.NoError(t, err)
+	})
+
+	t.Run("retrieve events nominal case", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got []flow.Event
+		err := RetrieveEvents(42, []flow.EventType{testTyp1, testTyp2}, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, append(testEvents1, testEvents2...), got)
+	})
+
+	t.Run("retrieve events returns all types when no filter given", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got []flow.Event
+		err := RetrieveEvents(42, []flow.EventType{}, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, append(testEvents1, testEvents2...), got)
+	})
+
+	t.Run("retrieve events does not include types not asked for", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got []flow.Event
+		err := RetrieveEvents(42, []flow.EventType{testTyp1, "another-type"}, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, testEvents1, got)
+	})
+
+	t.Run("retrieve events does not include types not asked for", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got []flow.Event
+		err := RetrieveEvents(42, []flow.EventType{testTyp2, "another-type"}, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, testEvents2, got)
+	})
+}
+
+func TestSaveAndRetrieve_Payload(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+
+	path, _ := ledger.ToPath([]byte("aac513eb1a0457700ac3fa8d292513e1"))
+	key := ledger.NewKey([]ledger.KeyPart{
+		ledger.NewKeyPart(0, []byte(`owner`)),
+		ledger.NewKeyPart(1, []byte(`controller`)),
+		ledger.NewKeyPart(2, []byte(`key`)),
+	})
+	payload1 := ledger.NewPayload(
+		key,
+		ledger.Value(`test1`),
+	)
+	payload2 := ledger.NewPayload(
+		key,
+		ledger.Value(`test2`),
+	)
+
+	t.Run("save two different payloads for same path at different heights", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+
+		err := SavePayload(42, path, payload1)(txn)
+
+		assert.NoError(t, err)
+
+		err = SavePayload(84, path, payload2)(txn)
+
+		assert.NoError(t, err)
+
+		err = txn.Commit()
+		require.NoError(t, err)
+	})
+
+	t.Run("retrieve payload at its first indexed height", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got ledger.Payload
+		err := RetrievePayload(42, path, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *payload1, got)
+	})
+
+	t.Run("retrieve payload at its second indexed height", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got ledger.Payload
+		err := RetrievePayload(84, path, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *payload2, got)
+	})
+
+	t.Run("retrieve payload between first and second indexed height", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got ledger.Payload
+		err := RetrievePayload(63, path, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *payload1, got)
+	})
+
+	t.Run("retrieve payload before it was ever indexed", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got ledger.Payload
+		err := RetrievePayload(63, path, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *payload1, got)
+	})
+
+	t.Run("retrieve payload after last indexed", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got ledger.Payload
+		err := RetrievePayload(999, path, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, *payload2, got)
+	})
+}
+
+func TestSaveAndRetrieve_Height(t *testing.T) {
+	db := helpers.InMemoryDB(t)
+	defer db.Close()
+
+	blockID, _ := flow.HexStringToIdentifier("aac513eb1a0457700ac3fa8d292513e18ad7fd70065146b35ab48fa5a6cab007")
+
+	t.Run("save height of block", func(t *testing.T) {
+		txn := db.NewTransaction(true)
+
+		err := SaveHeight(blockID, 42)(txn)
+
+		assert.NoError(t, err)
+
+		err = txn.Commit()
+		require.NoError(t, err)
+	})
+
+	t.Run("retrieve height of block", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got uint64
+		err := RetrieveHeight(blockID, &got)(txn)
+
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(42), got)
+	})
+}

--- a/service/storage/operations_test.go
+++ b/service/storage/operations_test.go
@@ -281,6 +281,15 @@ func TestSaveAndRetrieve_Payload(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, *payload2, got)
 	})
+
+	t.Run("should fail if path does not match", func(t *testing.T) {
+		txn := db.NewTransaction(false)
+
+		var got ledger.Payload
+		err := RetrievePayload(42, ledger.Path{}, &got)(txn)
+
+		assert.Error(t, err)
+	})
 }
 
 func TestSaveAndRetrieve_Height(t *testing.T) {

--- a/testing/helpers/badger.go
+++ b/testing/helpers/badger.go
@@ -1,0 +1,21 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func InMemoryDB(t *testing.T) *badger.DB {
+	t.Helper()
+
+	opts := badger.DefaultOptions("")
+	opts.InMemory = true
+	opts.Logger = nil
+
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	return db
+}


### PR DESCRIPTION
## Goal of this PR

Fixes #101 

Also introduces two very minor changes:

* Adds a `testing/helpers` package with a `badger.go` file for creating in-memory badger DBs. Adapts the tests that were using this (`chain/disk_test.go`).
* Switches the order of the parameters of `storage.SaveCommit` to start with the height at which we store the value, for consistency with all other functions.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date