### PR TITLE
Add bounded & concurrent cache

### DIFF
--- a/api/rosetta/data_balance_integration_test.go
+++ b/api/rosetta/data_balance_integration_test.go
@@ -93,7 +93,8 @@ func setupAPI(t *testing.T, db *badger.DB) *rosetta.Data {
 	config := configuration.New(params.ChainID)
 	validate := validator.New(params, index)
 	generate := scripts.NewGenerator(params)
-	invoke := invoker.New(index)
+	invoke, err := invoker.New(index)
+	require.NoError(t, err)
 	retrieve := retriever.New(params, index, validate, generate, invoke)
 	controller := rosetta.NewData(config, retrieve)
 

--- a/cmd/flow-dps-client/README.md
+++ b/cmd/flow-dps-client/README.md
@@ -10,11 +10,12 @@ It uses the Flow DPS Server's GRPC API as the backend to query the required data
 
 ```sh
 Usage of flow-dps-client:
-  -a, --api string      host for GRPC API server (default "127.0.0.1:5005")
+  -a, --api string      host for GRPC API server
+  -e, --cache uint      maximum cache size for register reads in bytes (default 1000000000)
   -h, --height uint     block height to execute the script at
-  -l, --log string      log output level (default "info")
+  -l, --level string    log output level (default "info")
   -p, --params string   comma-separated list of Cadence parameters
-  -s, --script string   path to Cadence script file (default "script.cdc")
+  -s, --script string   path to file with Cadence script (default "script.cdc")
 ```
 
 Cadence parameters can be provided as a list of comma-separated `Type(Value)` pairs.

--- a/cmd/flow-dps-client/main.go
+++ b/cmd/flow-dps-client/main.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
@@ -59,7 +60,7 @@ func run() int {
 	)
 
 	pflag.StringVarP(&flagAPI, "api", "a", "", "host for GRPC API server")
-	pflag.Uint64VarP(&flagCache, "cache", "e", 1e9, "maximum cache size for register reads in bytes")
+	pflag.Uint64VarP(&flagCache, "cache", "e", uint64(datasize.GB), "maximum cache size for register reads in bytes")
 	pflag.Uint64VarP(&flagHeight, "height", "h", 0, "block height to execute the script at")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 	pflag.StringVarP(&flagParams, "params", "p", "", "comma-separated list of Cadence parameters")

--- a/cmd/flow-dps-client/main.go
+++ b/cmd/flow-dps-client/main.go
@@ -51,6 +51,7 @@ func run() int {
 	// Command line parameter initialization.
 	var (
 		flagAPI    string
+		flagCache  uint64
 		flagHeight uint64
 		flagLevel  string
 		flagParams string
@@ -58,6 +59,7 @@ func run() int {
 	)
 
 	pflag.StringVarP(&flagAPI, "api", "a", "", "host for GRPC API server")
+	pflag.Uint64VarP(&flagCache, "cache", "e", 1e9, "maximum cache size for register reads in bytes")
 	pflag.Uint64VarP(&flagHeight, "height", "h", 0, "block height to execute the script at")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 	pflag.StringVarP(&flagParams, "params", "p", "", "comma-separated list of Cadence parameters")
@@ -119,7 +121,11 @@ func run() int {
 
 	// Execute the script using remote lookup and read.
 	client := dps.NewAPIClient(conn)
-	invoke := invoker.New(dps.IndexFromAPI(client))
+	invoke, err := invoker.New(dps.IndexFromAPI(client), invoker.WithCacheSize(flagCache))
+	if err != nil {
+		log.Error().Err(err).Msg("could not initialize invoker")
+		return failure
+	}
 	result, err := invoke.Script(flagHeight, script, args)
 	if err != nil {
 		log.Error().Err(err).Msg("could not invoke script")

--- a/cmd/flow-rosetta-server/README.md
+++ b/cmd/flow-rosetta-server/README.md
@@ -12,9 +12,10 @@ This allows the Rosetta API to access state remotely, or locally by running the 
 ```sh
 Usage of flow-dps-rosetta:
   -a, --api string     host URL for GRPC API endpoint (default "127.0.0.1:5005")
+  -e, --cache uint     maximum cache size for register reads in bytes (default 1000000000)
   -c, --chain string   chain ID for Flow network core contracts (default "flow-testnet")
-  -l, --log string     log output level (default "info")
-  -p, --port uint16    port to serve Rosetta API on (default 8080)
+  -l, --level string   log output level (default "info")
+  -p, --port uint16    port to host Rosetta API on (default 8080)
 ```
 
 ## Example

--- a/cmd/flow-rosetta-server/main.go
+++ b/cmd/flow-rosetta-server/main.go
@@ -23,6 +23,7 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
@@ -66,7 +67,7 @@ func run() int {
 	)
 
 	pflag.StringVarP(&flagAPI, "api", "a", "127.0.0.1:5005", "host URL for GRPC API endpoint")
-	pflag.Uint64VarP(&flagCache, "cache", "e", 1e9, "maximum cache size for register reads in bytes")
+	pflag.Uint64VarP(&flagCache, "cache", "e", uint64(datasize.GB), "maximum cache size for register reads in bytes")
 	pflag.StringVarP(&flagChain, "chain", "c", dps.FlowTestnet.String(), "chain ID for Flow network core contracts")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 	pflag.Uint16VarP(&flagPort, "port", "p", 8080, "port to host Rosetta API on")

--- a/cmd/flow-rosetta-server/main.go
+++ b/cmd/flow-rosetta-server/main.go
@@ -59,12 +59,14 @@ func run() int {
 	// Command line parameter initialization.
 	var (
 		flagAPI   string
+		flagCache uint64
 		flagChain string
 		flagLevel string
 		flagPort  uint16
 	)
 
 	pflag.StringVarP(&flagAPI, "api", "a", "127.0.0.1:5005", "host URL for GRPC API endpoint")
+	pflag.Uint64VarP(&flagCache, "cache", "e", 1e9, "maximum cache size for register reads in bytes")
 	pflag.StringVarP(&flagChain, "chain", "c", dps.FlowTestnet.String(), "chain ID for Flow network core contracts")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 	pflag.Uint16VarP(&flagPort, "port", "p", 8080, "port to host Rosetta API on")
@@ -103,7 +105,11 @@ func run() int {
 	config := configuration.New(params.ChainID)
 	validate := validator.New(params, index)
 	generate := scripts.NewGenerator(params)
-	invoke := invoker.New(index)
+	invoke, err := invoker.New(index, invoker.WithCacheSize(flagCache))
+	if err != nil {
+		log.Error().Err(err).Msg("could not initialize invoker")
+		return failure
+	}
 	retrieve := retriever.New(params, index, validate, generate, invoke)
 	ctrl := rosetta.NewData(config, retrieve)
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/dgraph-io/badger/v2 v2.2007.2
+	github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8
 	github.com/gammazero/deque v0.1.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.2

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/OneOfOne/xxhash v1.2.8
+	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/bytecodealliance/wasmtime-go v0.22.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
+github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2 h1:t8KYCwSKsOEZBFELI4Pn/phbp38iJ1RRAkDFNin1aak=
+github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/rosetta/invoker/config.go
+++ b/rosetta/invoker/config.go
@@ -14,12 +14,12 @@
 
 package invoker
 
+type Config struct {
+	CacheSize uint64
+}
+
 func WithCacheSize(size uint64) func(*Config) {
 	return func(cfg *Config) {
 		cfg.CacheSize = size
 	}
-}
-
-type Config struct {
-	CacheSize uint64
 }

--- a/rosetta/invoker/config.go
+++ b/rosetta/invoker/config.go
@@ -1,0 +1,25 @@
+// Copyright 2021 Alvalor S.A.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package invoker
+
+func WithCacheSize(size uint64) func(*Config) {
+	return func(cfg *Config) {
+		cfg.CacheSize = size
+	}
+}
+
+type Config struct {
+	CacheSize uint64
+}

--- a/rosetta/invoker/invoker.go
+++ b/rosetta/invoker/invoker.go
@@ -17,6 +17,7 @@ package invoker
 import (
 	"fmt"
 
+	"github.com/dgraph-io/ristretto"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/cadence"
@@ -36,21 +37,44 @@ import (
 type Invoker struct {
 	index index.Reader
 	vm    *fvm.VirtualMachine
-	reads map[uint64]delta.GetRegisterFunc
+	cache *ristretto.Cache
 }
 
-func New(index index.Reader) *Invoker {
+func New(index index.Reader, options ...func(*Config)) (*Invoker, error) {
 
+	// Initialize the invoker configuration with conservative default values.
+	cfg := Config{
+		CacheSize: 1e8, // ~100 MB default size
+	}
+
+	// Apply the option parameters provided by consumer.
+	for _, option := range options {
+		option(&cfg)
+	}
+
+	// Initialize interpreter and virtual machine for execution.
 	rt := fvm.NewInterpreterRuntime()
 	vm := fvm.NewVirtualMachine(rt)
+
+	// Initialize the Ristretto cache with the size limit. Ristretto recommends
+	// keeping ten times as many counters as items in the cache when full.
+	// Assuming an average item size of 1 kilobyte, this is what we get.
+	cache, err := ristretto.NewCache(&ristretto.Config{
+		NumCounters: int64(cfg.CacheSize) / 1000 * 10,
+		MaxCost:     int64(cfg.CacheSize),
+		BufferItems: 64,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize cache: %w", err)
+	}
 
 	i := Invoker{
 		index: index,
 		vm:    vm,
-		reads: make(map[uint64]delta.GetRegisterFunc),
+		cache: cache,
 	}
 
-	return &i
+	return &i, nil
 }
 
 // TODO: Find a way to batch up register requests for Cadence execution so we
@@ -79,12 +103,11 @@ func (i *Invoker) Script(height uint64, script []byte, arguments []cadence.Value
 	// that parameters related to the block are available from within the script
 	ctx := fvm.NewContext(zerolog.Nop(), fvm.WithBlockHeader(header))
 
-	// get the read function, if it was already initialized, to use the cache
-	read, ok := i.reads[height]
-	if !ok {
-		read = readRegister(i.index, height)
-		i.reads[height] = read
-	}
+	// Initialize the read function. We use a shared cache between all heights
+	// here. It's a smart cache, which means that items that are accessed often
+	// are more likely to be kept, regardless of height. This allows us to put
+	// an upper bound on total cache size while using it for all heights.
+	read := readRegister(i.index, i.cache, height)
 
 	// we initialize the view of the execution state on top of our ledger by
 	// using the read function at a specific commit

--- a/rosetta/invoker/invoker.go
+++ b/rosetta/invoker/invoker.go
@@ -17,6 +17,7 @@ package invoker
 import (
 	"fmt"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/dgraph-io/ristretto"
 	"github.com/rs/zerolog"
 
@@ -44,7 +45,7 @@ func New(index index.Reader, options ...func(*Config)) (*Invoker, error) {
 
 	// Initialize the invoker configuration with conservative default values.
 	cfg := Config{
-		CacheSize: 1e8, // ~100 MB default size
+		CacheSize: uint64(100 * datasize.MB), // ~100 MB default size
 	}
 
 	// Apply the option parameters provided by consumer.


### PR DESCRIPTION
## Goal of this PR

This PR adds an upper bound on cache size by using one shared smart cache for all index reads executed by the FVM.

Fixes #122.

Fixes #203.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date