### PR TITLE
Retrieving transactions - skip events with different transaction ID

### DIFF
--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -324,6 +324,11 @@ func (r *Retriever) Transaction(block identifier.Block, id identifier.Transactio
 	}
 	for _, event := range events {
 
+		// ignore events belonging to other transactions
+		if event.TransactionID.String() != id.Hash {
+			continue
+		}
+
 		// Decode the event payload into a Cadence value and cast to Cadence event.
 		value, err := json.Decode(event.Payload)
 		if err != nil {


### PR DESCRIPTION
## Goal of this PR

In a single block we can have multiple transactions with multiple events. We should skip events from different transactions when looking up a specific one.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date