### PR TITLE
Rosetta network endpoints integration tests

### DIFF
--- a/api/rosetta/data_balance_integration_test.go
+++ b/api/rosetta/data_balance_integration_test.go
@@ -17,11 +17,9 @@
 package rosetta_test
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -34,7 +32,6 @@ import (
 	"github.com/optakt/flow-dps/models/dps"
 	"github.com/optakt/flow-dps/rosetta/configuration"
 	"github.com/optakt/flow-dps/rosetta/identifier"
-	"github.com/optakt/flow-dps/rosetta/meta"
 )
 
 func TestAPI_Balance(t *testing.T) {
@@ -107,17 +104,8 @@ func TestAPI_Balance(t *testing.T) {
 
 			t.Parallel()
 
-			// prepare request payload (JSON)
-			enc, err := json.Marshal(test.request)
+			rec, ctx, err := setupRecorder(balanceEndpoint, test.request)
 			require.NoError(t, err)
-
-			// create request
-			req := httptest.NewRequest(http.MethodPost, "/account/balance", bytes.NewReader(enc))
-			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-
-			rec := httptest.NewRecorder()
-
-			ctx := echo.New().NewContext(req, rec)
 
 			// execute the request
 			err = api.Balance(ctx)
@@ -180,19 +168,18 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 
 		request rosetta.BalanceRequest
 
-		wantStatusCode              int
-		wantRosettaError            meta.ErrorDefinition
-		wantRosettaErrorDescription string
-		wantRosettaErrorDetails     map[string]interface{}
+		checkError assert.ErrorAssertionFunc
 	}{
 		{
 			name:    "empty balance request",
 			request: rosetta.BalanceRequest{},
 
-			wantStatusCode:              http.StatusBadRequest,
-			wantRosettaError:            configuration.ErrorInvalidFormat,
-			wantRosettaErrorDescription: "blockchain identifier: blockchain field is empty",
-			wantRosettaErrorDetails:     nil,
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"blockchain identifier: blockchain field is empty",
+				nil,
+			),
 		},
 		{
 			name: "missing blockchain name",
@@ -206,10 +193,12 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			wantStatusCode:              http.StatusBadRequest,
-			wantRosettaError:            configuration.ErrorInvalidFormat,
-			wantRosettaErrorDescription: "blockchain identifier: blockchain field is empty",
-			wantRosettaErrorDetails:     nil,
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"blockchain identifier: blockchain field is empty",
+				nil,
+			),
 		},
 		{
 			name: "invalid blockchain name",
@@ -223,10 +212,15 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			wantStatusCode:              http.StatusUnprocessableEntity,
-			wantRosettaError:            configuration.ErrorInvalidNetwork,
-			wantRosettaErrorDescription: fmt.Sprintf("invalid network identifier blockchain (have: %s, want: %s)", invalidBlockchain, dps.FlowBlockchain),
-			wantRosettaErrorDetails:     map[string]interface{}{"blockchain": invalidBlockchain, "network": dps.FlowTestnet.String()},
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidNetwork,
+				fmt.Sprintf("invalid network identifier blockchain (have: %s, want: %s)", invalidBlockchain, dps.FlowBlockchain),
+				map[string]interface{}{
+					"blockchain": invalidBlockchain,
+					"network":    dps.FlowTestnet.String(),
+				},
+			),
 		},
 		{
 			name: "missing network name",
@@ -239,11 +233,12 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    testBlock,
 				Currencies: defaultCurrency(),
 			},
-
-			wantStatusCode:              http.StatusBadRequest,
-			wantRosettaError:            configuration.ErrorInvalidFormat,
-			wantRosettaErrorDescription: "blockchain identifier: network field is empty",
-			wantRosettaErrorDetails:     nil,
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"blockchain identifier: network field is empty",
+				nil,
+			),
 		},
 		{
 			name: "invalid network name",
@@ -257,10 +252,15 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			wantStatusCode:              http.StatusUnprocessableEntity,
-			wantRosettaError:            configuration.ErrorInvalidNetwork,
-			wantRosettaErrorDescription: fmt.Sprintf("invalid network identifier network (have: %s, want: %s)", invalidNetwork, dps.FlowTestnet.String()),
-			wantRosettaErrorDetails:     map[string]interface{}{"blockchain": dps.FlowBlockchain, "network": invalidNetwork},
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidNetwork,
+				fmt.Sprintf("invalid network identifier network (have: %s, want: %s)", invalidNetwork, dps.FlowTestnet.String()),
+				map[string]interface{}{
+					"blockchain": dps.FlowBlockchain,
+					"network":    invalidNetwork,
+				},
+			),
 		},
 		{
 			name: "missing block index and height",
@@ -271,9 +271,11 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			wantStatusCode:              http.StatusBadRequest,
-			wantRosettaError:            configuration.ErrorInvalidFormat,
-			wantRosettaErrorDescription: "block identifier: at least one of hash or index is required",
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"block identifier: at least one of hash or index is required",
+				nil),
 		},
 		{
 			name: "invalid length of block id",
@@ -284,9 +286,12 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			wantStatusCode:              http.StatusBadRequest,
-			wantRosettaError:            configuration.ErrorInvalidFormat,
-			wantRosettaErrorDescription: fmt.Sprintf("block identifier: hash field has wrong length (have: %d, want: %d)", len(trimmedBlockHash), validBlockHashLen),
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				fmt.Sprintf("block identifier: hash field has wrong length (have: %d, want: %d)", len(trimmedBlockHash), validBlockHashLen),
+				nil,
+			),
 		},
 		{
 			name: "missing account address",
@@ -296,9 +301,13 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    testBlock,
 				Currencies: defaultCurrency(),
 			},
-			wantStatusCode:              http.StatusBadRequest,
-			wantRosettaError:            configuration.ErrorInvalidFormat,
-			wantRosettaErrorDescription: "account identifier: address field is empty",
+
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"account identifier: address field is empty",
+				nil,
+			),
 		},
 		{
 			name: "invalid length of account address",
@@ -308,9 +317,13 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    testBlock,
 				Currencies: defaultCurrency(),
 			},
-			wantStatusCode:              http.StatusBadRequest,
-			wantRosettaError:            configuration.ErrorInvalidFormat,
-			wantRosettaErrorDescription: fmt.Sprintf("account identifier: address field has wrong length (have: %d, want: %d)", len(trimmedAddress), validAddressSize),
+
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				fmt.Sprintf("account identifier: address field has wrong length (have: %d, want: %d)", len(trimmedAddress), validAddressSize),
+				nil,
+			),
 		},
 		{
 			name: "missing currency data",
@@ -320,9 +333,13 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    testBlock,
 				Currencies: []identifier.Currency{},
 			},
-			wantStatusCode:              http.StatusBadRequest,
-			wantRosettaError:            configuration.ErrorInvalidFormat,
-			wantRosettaErrorDescription: "currency identifiers: currency list is empty",
+
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"currency identifiers: currency list is empty",
+				nil,
+			),
 		},
 		{
 			name: "missing currency symbol",
@@ -332,9 +349,13 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    testBlock,
 				Currencies: []identifier.Currency{{Symbol: "", Decimals: 8}},
 			},
-			wantStatusCode:              http.StatusBadRequest,
-			wantRosettaError:            configuration.ErrorInvalidFormat,
-			wantRosettaErrorDescription: "currency identifier: symbol field is missing",
+
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"currency identifier: symbol field is missing",
+				nil,
+			),
 		},
 		{
 			name: "some currency symbols missing",
@@ -348,9 +369,13 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 					{Symbol: dps.FlowSymbol, Decimals: 8},
 				},
 			},
-			wantStatusCode:              http.StatusBadRequest,
-			wantRosettaError:            configuration.ErrorInvalidFormat,
-			wantRosettaErrorDescription: "currency identifier: symbol field is missing",
+
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"currency identifier: symbol field is missing",
+				nil,
+			),
 		},
 		{
 			name: "missing block height",
@@ -360,9 +385,13 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    identifier.Block{Hash: "af528bb047d6cd1400a326bb127d689607a096f5ccd81d8903dfebbac26afb23"},
 				Currencies: defaultCurrency(),
 			},
-			wantStatusCode:              http.StatusInternalServerError,
-			wantRosettaError:            configuration.ErrorInternal,
-			wantRosettaErrorDescription: "could not validate block: block access with hash currently not supported",
+
+			checkError: checkRosettaError(
+				http.StatusInternalServerError,
+				configuration.ErrorInternal,
+				"could not validate block: block access with hash currently not supported",
+				nil,
+			),
 		},
 		{
 			name: "invalid block hash",
@@ -372,10 +401,13 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    identifier.Block{Index: 13, Hash: invalidBlockHash},
 				Currencies: defaultCurrency(),
 			},
-			wantStatusCode:              http.StatusUnprocessableEntity,
-			wantRosettaError:            configuration.ErrorInvalidBlock,
-			wantRosettaErrorDescription: "block hash is not a valid hex-encoded string",
-			wantRosettaErrorDetails:     map[string]interface{}{"index": uint64(13), "hash": invalidBlockHash},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidBlock,
+				"block hash is not a valid hex-encoded string",
+				map[string]interface{}{"index": uint64(13), "hash": invalidBlockHash},
+			),
 		},
 		{
 			name: "unkown block requested",
@@ -385,10 +417,13 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    identifier.Block{Index: 426},
 				Currencies: defaultCurrency(),
 			},
-			wantStatusCode:              http.StatusUnprocessableEntity,
-			wantRosettaError:            configuration.ErrorUnknownBlock,
-			wantRosettaErrorDescription: "block index is above last indexed block (last: 425)",
-			wantRosettaErrorDetails:     map[string]interface{}{"index": uint64(426), "hash": ""},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorUnknownBlock,
+				"block index is above last indexed block (last: 425)",
+				map[string]interface{}{"index": uint64(426), "hash": ""},
+			),
 		},
 		{
 			name: "mismatched block id and height",
@@ -398,10 +433,16 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    identifier.Block{Index: 13, Hash: "9035c558379b208eba11130c928537fe50ad93cdee314980fccb695aa31df7fc"},
 				Currencies: defaultCurrency(),
 			},
-			wantStatusCode:              http.StatusUnprocessableEntity,
-			wantRosettaError:            configuration.ErrorInvalidBlock,
-			wantRosettaErrorDescription: "block hash does not match known hash for height (known: af528bb047d6cd1400a326bb127d689607a096f5ccd81d8903dfebbac26afb23)",
-			wantRosettaErrorDetails:     map[string]interface{}{"index": uint64(13), "hash": "9035c558379b208eba11130c928537fe50ad93cdee314980fccb695aa31df7fc"},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidBlock,
+				"block hash does not match known hash for height (known: af528bb047d6cd1400a326bb127d689607a096f5ccd81d8903dfebbac26afb23)",
+				map[string]interface{}{
+					"index": uint64(13),
+					"hash":  "9035c558379b208eba11130c928537fe50ad93cdee314980fccb695aa31df7fc",
+				},
+			),
 		},
 		{
 			name: "invalid account ID hex",
@@ -411,10 +452,16 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    testBlock,
 				Currencies: defaultCurrency(),
 			},
-			wantStatusCode:              http.StatusUnprocessableEntity,
-			wantRosettaError:            configuration.ErrorInvalidAccount,
-			wantRosettaErrorDescription: "account address is not a valid hex-encoded string",
-			wantRosettaErrorDetails:     map[string]interface{}{"address": invalidAddressHex, "chain": dps.FlowTestnet.String()},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidAccount,
+				"account address is not a valid hex-encoded string",
+				map[string]interface{}{
+					"address": invalidAddressHex,
+					"chain":   dps.FlowTestnet.String(),
+				},
+			),
 		},
 		{
 			name: "invalid account ID",
@@ -424,10 +471,16 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    testBlock,
 				Currencies: defaultCurrency(),
 			},
-			wantStatusCode:              http.StatusUnprocessableEntity,
-			wantRosettaError:            configuration.ErrorInvalidAccount,
-			wantRosettaErrorDescription: "account address is not valid for configured chain",
-			wantRosettaErrorDetails:     map[string]interface{}{"address": invalidAddress, "chain": dps.FlowTestnet.String()},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidAccount,
+				"account address is not valid for configured chain",
+				map[string]interface{}{
+					"address": invalidAddress,
+					"chain":   dps.FlowTestnet.String(),
+				},
+			),
 		},
 		{
 			name: "unknown currency requested",
@@ -437,10 +490,16 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    testBlock,
 				Currencies: []identifier.Currency{{Symbol: invalidToken, Decimals: 8}},
 			},
-			wantStatusCode:              http.StatusUnprocessableEntity,
-			wantRosettaError:            configuration.ErrorUnknownCurrency,
-			wantRosettaErrorDescription: "currency symbol has not been configured",
-			wantRosettaErrorDetails:     map[string]interface{}{"symbol": invalidToken, "decimals": uint(8)},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorUnknownCurrency,
+				"currency symbol has not been configured",
+				map[string]interface{}{
+					"symbol":   invalidToken,
+					"decimals": uint(8),
+				},
+			),
 		},
 		{
 			name: "invalid currency decimal count",
@@ -450,10 +509,16 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    testBlock,
 				Currencies: []identifier.Currency{{Symbol: dps.FlowSymbol, Decimals: 7}},
 			},
-			wantStatusCode:              http.StatusUnprocessableEntity,
-			wantRosettaError:            configuration.ErrorInvalidCurrency,
-			wantRosettaErrorDescription: fmt.Sprintf("currency decimals do not match configured default (default: %d)", dps.FlowDecimals),
-			wantRosettaErrorDetails:     map[string]interface{}{"symbol": dps.FlowSymbol, "decimals": uint(7)},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidCurrency,
+				fmt.Sprintf("currency decimals do not match configured default (default: %d)", dps.FlowDecimals),
+				map[string]interface{}{
+					"symbol":   dps.FlowSymbol,
+					"decimals": uint(7),
+				},
+			),
 		},
 		{
 			name: "invalid currency decimal count in a list of currencies",
@@ -467,10 +532,16 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 					{Symbol: dps.FlowSymbol, Decimals: dps.FlowDecimals},
 				},
 			},
-			wantStatusCode:              http.StatusUnprocessableEntity,
-			wantRosettaError:            configuration.ErrorInvalidCurrency,
-			wantRosettaErrorDescription: fmt.Sprintf("currency decimals do not match configured default (default: %d)", dps.FlowDecimals),
-			wantRosettaErrorDetails:     map[string]interface{}{"symbol": dps.FlowSymbol, "decimals": uint(7)},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidCurrency,
+				fmt.Sprintf("currency decimals do not match configured default (default: %d)", dps.FlowDecimals),
+				map[string]interface{}{
+					"symbol":   dps.FlowSymbol,
+					"decimals": uint(7),
+				},
+			),
 		},
 		{
 			// request the account balance before the account is created, so the account/vault does not exist.
@@ -483,9 +554,13 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    identifier.Block{Index: accFirstOccurrence - 1}, // one block before the account is created
 				Currencies: defaultCurrency(),
 			},
-			wantStatusCode:              http.StatusInternalServerError,
-			wantRosettaError:            configuration.ErrorInternal,
-			wantRosettaErrorDescription: cadenceVaultNotFoundErr,
+
+			checkError: checkRosettaError(
+				http.StatusInternalServerError,
+				configuration.ErrorInternal,
+				cadenceVaultNotFoundErr,
+				nil,
+			),
 		},
 	}
 
@@ -496,31 +571,12 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 
 			t.Parallel()
 
-			enc, err := json.Marshal(test.request)
+			_, ctx, err := setupRecorder(balanceEndpoint, test.request)
 			require.NoError(t, err)
-
-			// create request
-			req := httptest.NewRequest(http.MethodPost, "/account/balance", bytes.NewReader(enc))
-			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-
-			rec := httptest.NewRecorder()
-
-			ctx := echo.New().NewContext(req, rec)
 
 			// execute the request
 			err = api.Balance(ctx)
-			assert.Error(t, err)
-
-			echoErr, ok := err.(*echo.HTTPError)
-			require.True(t, ok)
-
-			assert.Equal(t, test.wantStatusCode, echoErr.Code)
-			gotErr, ok := echoErr.Message.(rosetta.Error)
-			require.True(t, ok)
-
-			assert.Equal(t, test.wantRosettaError, gotErr.ErrorDefinition)
-			assert.Equal(t, test.wantRosettaErrorDescription, gotErr.Description)
-			assert.Equal(t, test.wantRosettaErrorDetails, gotErr.Details)
+			test.checkError(t, err)
 		})
 	}
 }
@@ -574,24 +630,30 @@ func TestAPI_BalanceHandlesMalformedRequest(t *testing.T) {
 	)
 
 	tests := []struct {
-		name     string
-		payload  []byte
-		mimeType string
+		name    string
+		payload []byte
+		prepare func(req *http.Request)
 	}{
 		{
-			name:     "wrong field type",
-			payload:  []byte(wrongFieldType),
-			mimeType: echo.MIMEApplicationJSON,
+			name:    "wrong field type",
+			payload: []byte(wrongFieldType),
+			prepare: func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			},
 		},
 		{
-			name:     "unclosed bracket",
-			payload:  []byte(unclosedBracket),
-			mimeType: echo.MIMEApplicationJSON,
+			name:    "unclosed bracket",
+			payload: []byte(unclosedBracket),
+			prepare: func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			},
 		},
 		{
-			name:     "valid payload with no mime type set",
-			payload:  []byte(validJSON),
-			mimeType: "",
+			name:    "valid payload with no MIME type set",
+			payload: []byte(validJSON),
+			prepare: func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, "")
+			},
 		},
 	}
 
@@ -602,16 +664,11 @@ func TestAPI_BalanceHandlesMalformedRequest(t *testing.T) {
 
 			t.Parallel()
 
-			// create request
-			req := httptest.NewRequest(http.MethodPost, "/account/balance", bytes.NewReader(test.payload))
-			req.Header.Set(echo.HeaderContentType, test.mimeType)
-
-			rec := httptest.NewRecorder()
-
-			ctx := echo.New().NewContext(req, rec)
+			_, ctx, err := setupRecorder(balanceEndpoint, test.payload, test.prepare)
+			require.NoError(t, err)
 
 			// execute the request
-			err := api.Balance(ctx)
+			err = api.Balance(ctx)
 
 			// verify the errors
 

--- a/api/rosetta/data_balance_integration_test.go
+++ b/api/rosetta/data_balance_integration_test.go
@@ -275,7 +275,8 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				http.StatusBadRequest,
 				configuration.ErrorInvalidFormat,
 				"block identifier: at least one of hash or index is required",
-				nil),
+				nil,
+			),
 		},
 		{
 			name: "invalid length of block id",
@@ -422,7 +423,10 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				http.StatusUnprocessableEntity,
 				configuration.ErrorUnknownBlock,
 				"block index is above last indexed block (last: 425)",
-				map[string]interface{}{"index": uint64(426), "hash": ""},
+				map[string]interface{}{
+					"index": uint64(426),
+					"hash":  "",
+				},
 			),
 		},
 		{

--- a/api/rosetta/data_balance_integration_test.go
+++ b/api/rosetta/data_balance_integration_test.go
@@ -18,15 +18,12 @@ package rosetta_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/onflow/flow-go/model/flow"
 
 	"github.com/optakt/flow-dps/api/rosetta"
 	"github.com/optakt/flow-dps/models/dps"
@@ -146,8 +143,6 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 			Index: 13,
 			Hash:  "af528bb047d6cd1400a326bb127d689607a096f5ccd81d8903dfebbac26afb23",
 		}
-
-		validAddressSize = 2 * flow.AddressLength
 	)
 
 	const (
@@ -174,12 +169,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 			name:    "empty balance request",
 			request: rosetta.BalanceRequest{},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: blockchain field is empty",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "missing blockchain name",
@@ -193,12 +183,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: blockchain field is empty",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid blockchain name",
@@ -212,15 +197,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidNetwork,
-				fmt.Sprintf("invalid network identifier blockchain (have: %s, want: %s)", invalidBlockchain, dps.FlowBlockchain),
-				map[string]interface{}{
-					"blockchain": invalidBlockchain,
-					"network":    dps.FlowTestnet.String(),
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidNetwork),
 		},
 		{
 			name: "missing network name",
@@ -233,12 +210,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				BlockID:    testBlock,
 				Currencies: defaultCurrency(),
 			},
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: network field is empty",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid network name",
@@ -252,15 +224,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidNetwork,
-				fmt.Sprintf("invalid network identifier network (have: %s, want: %s)", invalidNetwork, dps.FlowTestnet.String()),
-				map[string]interface{}{
-					"blockchain": dps.FlowBlockchain,
-					"network":    invalidNetwork,
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidNetwork),
 		},
 		{
 			name: "missing block index and height",
@@ -271,12 +235,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"block identifier: at least one of hash or index is required",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid length of block id",
@@ -287,12 +246,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				fmt.Sprintf("block identifier: hash field has wrong length (have: %d, want: %d)", len(trimmedBlockHash), validBlockHashLen),
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "missing account address",
@@ -303,12 +257,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"account identifier: address field is empty",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid length of account address",
@@ -319,12 +268,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				fmt.Sprintf("account identifier: address field has wrong length (have: %d, want: %d)", len(trimmedAddress), validAddressSize),
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "missing currency data",
@@ -335,12 +279,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: []identifier.Currency{},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"currency identifiers: currency list is empty",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "missing currency symbol",
@@ -351,12 +290,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: []identifier.Currency{{Symbol: "", Decimals: 8}},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"currency identifier: symbol field is missing",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "some currency symbols missing",
@@ -371,12 +305,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"currency identifier: symbol field is missing",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "missing block height",
@@ -387,12 +316,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusInternalServerError,
-				configuration.ErrorInternal,
-				"could not validate block: block access with hash currently not supported",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusInternalServerError, configuration.ErrorInternal),
 		},
 		{
 			name: "invalid block hash",
@@ -403,12 +327,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidBlock,
-				"block hash is not a valid hex-encoded string",
-				map[string]interface{}{"index": uint64(13), "hash": invalidBlockHash},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidBlock),
 		},
 		{
 			name: "unkown block requested",
@@ -419,15 +338,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorUnknownBlock,
-				"block index is above last indexed block (last: 425)",
-				map[string]interface{}{
-					"index": uint64(426),
-					"hash":  "",
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorUnknownBlock),
 		},
 		{
 			name: "mismatched block id and height",
@@ -438,15 +349,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidBlock,
-				"block hash does not match known hash for height (known: af528bb047d6cd1400a326bb127d689607a096f5ccd81d8903dfebbac26afb23)",
-				map[string]interface{}{
-					"index": uint64(13),
-					"hash":  "9035c558379b208eba11130c928537fe50ad93cdee314980fccb695aa31df7fc",
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidBlock),
 		},
 		{
 			name: "invalid account ID hex",
@@ -457,15 +360,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidAccount,
-				"account address is not a valid hex-encoded string",
-				map[string]interface{}{
-					"address": invalidAddressHex,
-					"chain":   dps.FlowTestnet.String(),
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidAccount),
 		},
 		{
 			name: "invalid account ID",
@@ -476,15 +371,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidAccount,
-				"account address is not valid for configured chain",
-				map[string]interface{}{
-					"address": invalidAddress,
-					"chain":   dps.FlowTestnet.String(),
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidAccount),
 		},
 		{
 			name: "unknown currency requested",
@@ -495,15 +382,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: []identifier.Currency{{Symbol: invalidToken, Decimals: 8}},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorUnknownCurrency,
-				"currency symbol has not been configured",
-				map[string]interface{}{
-					"symbol":   invalidToken,
-					"decimals": uint(8),
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorUnknownCurrency),
 		},
 		{
 			name: "invalid currency decimal count",
@@ -514,15 +393,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: []identifier.Currency{{Symbol: dps.FlowSymbol, Decimals: 7}},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidCurrency,
-				fmt.Sprintf("currency decimals do not match configured default (default: %d)", dps.FlowDecimals),
-				map[string]interface{}{
-					"symbol":   dps.FlowSymbol,
-					"decimals": uint(7),
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidCurrency),
 		},
 		{
 			name: "invalid currency decimal count in a list of currencies",
@@ -537,15 +408,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidCurrency,
-				fmt.Sprintf("currency decimals do not match configured default (default: %d)", dps.FlowDecimals),
-				map[string]interface{}{
-					"symbol":   dps.FlowSymbol,
-					"decimals": uint(7),
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidCurrency),
 		},
 		{
 			// request the account balance before the account is created, so the account/vault does not exist.
@@ -559,12 +422,7 @@ func TestAPI_BalanceHandlesErrors(t *testing.T) {
 				Currencies: defaultCurrency(),
 			},
 
-			checkError: checkRosettaError(
-				http.StatusInternalServerError,
-				configuration.ErrorInternal,
-				cadenceVaultNotFoundErr,
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusInternalServerError, configuration.ErrorInternal),
 		},
 	}
 

--- a/api/rosetta/data_block_integration_test.go
+++ b/api/rosetta/data_block_integration_test.go
@@ -47,11 +47,11 @@ func TestAPI_Block(t *testing.T) {
 
 	// headers of known blocks we want to verify
 	var (
-		firstHeader = knownHeaders(1)
-		midHeader1  = knownHeaders(13)
-		midHeader2  = knownHeaders(43)
-		midHeader3  = knownHeaders(44)
-		lastHeader  = knownHeaders(425) // header of last indexed block
+		firstHeader = knownHeader(1)
+		midHeader1  = knownHeader(13)
+		midHeader2  = knownHeader(43)
+		midHeader3  = knownHeader(44)
+		lastHeader  = knownHeader(425) // header of last indexed block
 	)
 
 	const (
@@ -217,7 +217,8 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				BlockID: validBlockID,
 			},
 
-			checkErr: checkRosettaError(http.StatusUnprocessableEntity,
+			checkErr: checkRosettaError(
+				http.StatusUnprocessableEntity,
 				configuration.ErrorInvalidNetwork,
 				fmt.Sprintf("invalid network identifier blockchain (have: %s, want: %s)", invalidBlockchain, dps.FlowBlockchain),
 				map[string]interface{}{
@@ -236,7 +237,8 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				BlockID: validBlockID,
 			},
 
-			checkErr: checkRosettaError(http.StatusBadRequest,
+			checkErr: checkRosettaError(
+				http.StatusBadRequest,
 				configuration.ErrorInvalidFormat,
 				"blockchain identifier: network field is empty",
 				nil,
@@ -252,7 +254,8 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				BlockID: validBlockID,
 			},
 
-			checkErr: checkRosettaError(http.StatusUnprocessableEntity,
+			checkErr: checkRosettaError(
+				http.StatusUnprocessableEntity,
 				configuration.ErrorInvalidNetwork,
 				fmt.Sprintf("invalid network identifier network (have: %s, want: %s)", invalidNetwork, dps.FlowTestnet.String()),
 				map[string]interface{}{
@@ -271,7 +274,8 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(http.StatusBadRequest,
+			checkErr: checkRosettaError(
+				http.StatusBadRequest,
 				configuration.ErrorInvalidFormat,
 				"block identifier: at least one of hash or index is required",
 				nil,
@@ -287,7 +291,8 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(http.StatusBadRequest,
+			checkErr: checkRosettaError(
+				http.StatusBadRequest,
 				configuration.ErrorInvalidFormat,
 				fmt.Sprintf("block identifier: hash field has wrong length (have: %d, want: %d)", len(trimmedBlockHash), validBlockHashLen),
 				nil,
@@ -302,7 +307,8 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(http.StatusInternalServerError,
+			checkErr: checkRosettaError(
+				http.StatusInternalServerError,
 				configuration.ErrorInternal,
 				"could not validate block: block access with hash currently not supported",
 				nil,
@@ -318,7 +324,8 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(http.StatusUnprocessableEntity,
+			checkErr: checkRosettaError(
+				http.StatusUnprocessableEntity,
 				configuration.ErrorInvalidBlock,
 				"block hash is not a valid hex-encoded string",
 				map[string]interface{}{
@@ -336,7 +343,8 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(http.StatusUnprocessableEntity,
+			checkErr: checkRosettaError(
+				http.StatusUnprocessableEntity,
 				configuration.ErrorUnknownBlock,
 				fmt.Sprintf("block index is above last indexed block (last: %d)", lastHeight),
 				map[string]interface{}{
@@ -355,9 +363,10 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(http.StatusUnprocessableEntity,
+			checkErr: checkRosettaError(
+				http.StatusUnprocessableEntity,
 				configuration.ErrorInvalidBlock,
-				fmt.Sprintf("block hash does not match known hash for height (known: %s)", knownHeaders(validBlockHeight-1).ID().String()),
+				fmt.Sprintf("block hash does not match known hash for height (known: %s)", knownHeader(validBlockHeight-1).ID().String()),
 				map[string]interface{}{
 					"index": uint64(validBlockHeight - 1),
 					"hash":  validBlockHash,
@@ -369,7 +378,8 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 			name:    "empty block request",
 			request: rosetta.BlockRequest{},
 
-			checkErr: checkRosettaError(http.StatusBadRequest,
+			checkErr: checkRosettaError(
+				http.StatusBadRequest,
 				configuration.ErrorInvalidFormat,
 				"blockchain identifier: blockchain field is empty",
 				nil,

--- a/api/rosetta/data_block_integration_test.go
+++ b/api/rosetta/data_block_integration_test.go
@@ -18,7 +18,6 @@ package rosetta_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 	"testing"
@@ -200,12 +199,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				BlockID: validBlockID,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: blockchain field is empty",
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid blockchain name",
@@ -217,15 +211,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				BlockID: validBlockID,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidNetwork,
-				fmt.Sprintf("invalid network identifier blockchain (have: %s, want: %s)", invalidBlockchain, dps.FlowBlockchain),
-				map[string]interface{}{
-					"blockchain": invalidBlockchain,
-					"network":    dps.FlowTestnet.String(),
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidNetwork),
 		},
 		{
 			name: "missing network name",
@@ -237,12 +223,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				BlockID: validBlockID,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: network field is empty",
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid network name",
@@ -254,15 +235,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				BlockID: validBlockID,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidNetwork,
-				fmt.Sprintf("invalid network identifier network (have: %s, want: %s)", invalidNetwork, dps.FlowTestnet.String()),
-				map[string]interface{}{
-					"blockchain": dps.FlowBlockchain,
-					"network":    invalidNetwork,
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidNetwork),
 		},
 		{
 			name: "missing block height and hash",
@@ -274,12 +247,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"block identifier: at least one of hash or index is required",
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid length of block id",
@@ -291,12 +259,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				fmt.Sprintf("block identifier: hash field has wrong length (have: %d, want: %d)", len(trimmedBlockHash), validBlockHashLen),
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "missing block height",
@@ -307,12 +270,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusInternalServerError,
-				configuration.ErrorInternal,
-				"could not validate block: block access with hash currently not supported",
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusInternalServerError, configuration.ErrorInternal),
 		},
 		{
 			name: "invalid block hash",
@@ -324,15 +282,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidBlock,
-				"block hash is not a valid hex-encoded string",
-				map[string]interface{}{
-					"index": uint64(13),
-					"hash":  invalidBlockHash,
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidBlock),
 		},
 		{
 			name: "unknown block",
@@ -343,15 +293,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorUnknownBlock,
-				fmt.Sprintf("block index is above last indexed block (last: %d)", lastHeight),
-				map[string]interface{}{
-					"index": uint64(426),
-					"hash":  "",
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorUnknownBlock),
 		},
 		{
 			name: "mismatched block height and hash",
@@ -363,15 +305,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidBlock,
-				fmt.Sprintf("block hash does not match known hash for height (known: %s)", knownHeader(validBlockHeight-1).ID().String()),
-				map[string]interface{}{
-					"index": uint64(validBlockHeight - 1),
-					"hash":  validBlockHash,
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidBlock),
 		},
 		{
 			// effectively the same as the 'missing blockchain name' test case, since it's the first check we'll do
@@ -381,8 +315,6 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 			checkErr: checkRosettaError(
 				http.StatusBadRequest,
 				configuration.ErrorInvalidFormat,
-				"blockchain identifier: blockchain field is empty",
-				nil,
 			),
 		},
 	}

--- a/api/rosetta/data_block_integration_test.go
+++ b/api/rosetta/data_block_integration_test.go
@@ -312,10 +312,7 @@ func TestAPI_BlockHandlesErrors(t *testing.T) {
 			name:    "empty block request",
 			request: rosetta.BlockRequest{},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 	}
 

--- a/api/rosetta/data_integration_test.go
+++ b/api/rosetta/data_integration_test.go
@@ -136,7 +136,7 @@ func setupRecorder(endpoint string, input interface{}, options ...func(*http.Req
 	return rec, ctx, nil
 }
 
-func checkRosettaError(statusCode int, def meta.ErrorDefinition, desc string, details map[string]interface{}) func(t assert.TestingT, err error, v ...interface{}) bool {
+func checkRosettaError(statusCode int, def meta.ErrorDefinition) func(t assert.TestingT, err error, v ...interface{}) bool {
 
 	return func(t assert.TestingT, err error, v ...interface{}) bool {
 
@@ -159,8 +159,6 @@ func checkRosettaError(statusCode int, def meta.ErrorDefinition, desc string, de
 		}
 
 		success = success && assert.Equal(t, def, gotErr.ErrorDefinition)
-		success = success && assert.Equal(t, desc, gotErr.Description)
-		success = success && assert.Equal(t, details, gotErr.Details)
 
 		return success
 	}

--- a/api/rosetta/data_integration_test.go
+++ b/api/rosetta/data_integration_test.go
@@ -113,20 +113,13 @@ func setupAPI(t *testing.T, db *badger.DB) *rosetta.Data {
 
 func setupRecorder(endpoint string, input interface{}, options ...func(*http.Request)) (*httptest.ResponseRecorder, echo.Context, error) {
 
-	var payload []byte
-
-	switch input.(type) {
-
-	case []byte:
-		payload = input.([]byte)
-
-	default:
-		enc, err := json.Marshal(input)
+	payload, ok := input.([]byte)
+	if !ok {
+		var err error
+		payload, err = json.Marshal(input)
 		if err != nil {
 			return nil, echo.New().AcquireContext(), fmt.Errorf("could not encode input: %w", err)
 		}
-
-		payload = enc
 	}
 
 	req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewReader(payload))
@@ -205,8 +198,7 @@ func validateByHeader(t *testing.T, header flow.Header) validateBlockFunc {
 	return validateBlock(t, header.Height, header.ID().String())
 }
 
-// add header for block 165 and 181
-func knownHeaders(height uint64) flow.Header {
+func knownHeader(height uint64) flow.Header {
 
 	switch height {
 

--- a/api/rosetta/data_integration_test.go
+++ b/api/rosetta/data_integration_test.go
@@ -139,27 +139,24 @@ func setupRecorder(endpoint string, input interface{}, options ...func(*http.Req
 func checkRosettaError(statusCode int, def meta.ErrorDefinition) func(t assert.TestingT, err error, v ...interface{}) bool {
 
 	return func(t assert.TestingT, err error, v ...interface{}) bool {
-
 		// return false if any of the asserts failed
-
 		success := true
-
 		success = success && assert.Error(t, err)
 
-		echoErr, ok := err.(*echo.HTTPError)
-		if !assert.True(t, ok) {
+		if !assert.IsType(t, &echo.HTTPError{}, err) {
 			return false
 		}
+		echoErr := err.(*echo.HTTPError)
 
 		success = success && assert.Equal(t, statusCode, echoErr.Code)
 
-		gotErr, ok := echoErr.Message.(rosetta.Error)
-		if !assert.True(t, ok) {
+		if !assert.IsType(t, rosetta.Error{}, echoErr.Message) {
 			return false
 		}
 
-		success = success && assert.Equal(t, def, gotErr.ErrorDefinition)
+		gotErr := echoErr.Message.(rosetta.Error)
 
+		success = success && assert.Equal(t, def, gotErr.ErrorDefinition)
 		return success
 	}
 }

--- a/api/rosetta/data_network_integration_test.go
+++ b/api/rosetta/data_network_integration_test.go
@@ -233,31 +233,39 @@ func TestAPI_Options(t *testing.T) {
 
 			switch expectedCode {
 
-			case 1:
+			case configuration.ErrorInternal.Code:
 				assert.Equal(t, configuration.ErrorInternal.Message, rosettaErr.Message)
 				assert.Equal(t, configuration.ErrorInternal.Retriable, rosettaErr.Retriable)
-			case 2:
+
+			case configuration.ErrorInvalidFormat.Code:
 				assert.Equal(t, configuration.ErrorInvalidFormat.Message, rosettaErr.Message)
 				assert.Equal(t, configuration.ErrorInvalidFormat.Retriable, rosettaErr.Retriable)
-			case 3:
+
+			case configuration.ErrorInvalidNetwork.Code:
 				assert.Equal(t, configuration.ErrorInvalidNetwork.Message, rosettaErr.Message)
 				assert.Equal(t, configuration.ErrorInvalidNetwork.Retriable, rosettaErr.Retriable)
-			case 4:
+
+			case configuration.ErrorInvalidAccount.Code:
 				assert.Equal(t, configuration.ErrorInvalidAccount.Message, rosettaErr.Message)
 				assert.Equal(t, configuration.ErrorInvalidAccount.Retriable, rosettaErr.Retriable)
-			case 5:
+
+			case configuration.ErrorInvalidCurrency.Code:
 				assert.Equal(t, configuration.ErrorInvalidCurrency.Message, rosettaErr.Message)
 				assert.Equal(t, configuration.ErrorInvalidCurrency.Retriable, rosettaErr.Retriable)
-			case 6:
+
+			case configuration.ErrorInvalidBlock.Code:
 				assert.Equal(t, configuration.ErrorInvalidBlock.Message, rosettaErr.Message)
 				assert.Equal(t, configuration.ErrorInvalidBlock.Retriable, rosettaErr.Retriable)
-			case 7:
+
+			case configuration.ErrorInvalidTransaction.Code:
 				assert.Equal(t, configuration.ErrorInvalidTransaction.Message, rosettaErr.Message)
 				assert.Equal(t, configuration.ErrorInvalidTransaction.Retriable, rosettaErr.Retriable)
-			case 8:
+
+			case configuration.ErrorUnknownBlock.Code:
 				assert.Equal(t, configuration.ErrorUnknownBlock.Message, rosettaErr.Message)
 				assert.Equal(t, configuration.ErrorUnknownBlock.Retriable, rosettaErr.Retriable)
-			case 9:
+
+			case configuration.ErrorUnknownCurrency.Code:
 				assert.Equal(t, configuration.ErrorUnknownCurrency.Message, rosettaErr.Message)
 				assert.Equal(t, configuration.ErrorUnknownCurrency.Retriable, rosettaErr.Retriable)
 

--- a/api/rosetta/data_network_integration_test.go
+++ b/api/rosetta/data_network_integration_test.go
@@ -18,7 +18,6 @@ package rosetta_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"regexp"
 	"testing"
@@ -95,12 +94,7 @@ func TestAPI_StatusHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: blockchain field is missing",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid blockchain",
@@ -111,15 +105,7 @@ func TestAPI_StatusHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidNetwork,
-				fmt.Sprintf("invalid network identifier blockchain (have: %s, want: %s)", invalidBlockchain, dps.FlowBlockchain),
-				map[string]interface{}{
-					"blockchain": invalidBlockchain,
-					"network":    dps.FlowTestnet.String(),
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidNetwork),
 		},
 		{
 			name: "missing network",
@@ -130,11 +116,7 @@ func TestAPI_StatusHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: network field is missing",
-				nil),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid network",
@@ -145,15 +127,7 @@ func TestAPI_StatusHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidNetwork,
-				fmt.Sprintf("invalid network identifier network (have: %s, want: %s)", invalidNetwork, dps.FlowTestnet.String()),
-				map[string]interface{}{
-					"blockchain": dps.FlowBlockchain,
-					"network":    invalidNetwork,
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidNetwork),
 		},
 	}
 
@@ -316,12 +290,7 @@ func TestAPI_OptionsHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: blockchain field is missing",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid blockchain",
@@ -332,15 +301,7 @@ func TestAPI_OptionsHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidNetwork,
-				fmt.Sprintf("invalid network identifier blockchain (have: %s, want: %s)", invalidBlockchain, dps.FlowBlockchain),
-				map[string]interface{}{
-					"blockchain": invalidBlockchain,
-					"network":    dps.FlowTestnet.String(),
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidNetwork),
 		},
 		{
 			name: "missing network",
@@ -351,12 +312,7 @@ func TestAPI_OptionsHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: network field is missing",
-				nil,
-			),
+			checkError: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid network",
@@ -367,15 +323,7 @@ func TestAPI_OptionsHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkError: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidNetwork,
-				fmt.Sprintf("invalid network identifier network (have: %s, want: %s)", invalidNetwork, dps.FlowTestnet.String()),
-				map[string]interface{}{
-					"blockchain": dps.FlowBlockchain,
-					"network":    invalidNetwork,
-				},
-			),
+			checkError: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidNetwork),
 		},
 	}
 

--- a/api/rosetta/data_network_integration_test.go
+++ b/api/rosetta/data_network_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/optakt/flow-dps/api/rosetta"
+	"github.com/optakt/flow-dps/models/convert"
 	"github.com/optakt/flow-dps/models/dps"
 	"github.com/optakt/flow-dps/rosetta/configuration"
 	"github.com/optakt/flow-dps/rosetta/identifier"
@@ -158,7 +159,7 @@ func TestAPI_Status(t *testing.T) {
 			// verify current block
 			assert.Equal(t, status.CurrentBlockID.Index, lastBlock.Height)
 			assert.Equal(t, status.CurrentBlockID.Hash, lastBlock.ID().String())
-			assert.Equal(t, status.CurrentBlockTimestamp, rosettaTime(lastBlock.Timestamp))
+			assert.Equal(t, status.CurrentBlockTimestamp, convert.RosettaTime(lastBlock.Timestamp))
 
 			// verify oldest block
 			assert.Equal(t, status.OldestBlockID.Hash, oldestBlockID)

--- a/api/rosetta/data_network_integration_test.go
+++ b/api/rosetta/data_network_integration_test.go
@@ -179,7 +179,7 @@ func TestAPI_Options(t *testing.T) {
 	db := setupDB(t)
 	api := setupAPI(t, db)
 
-	const errorCount = 9
+	const wantErrorCount = 9
 
 	// verify version string is in the format of x.y.z
 	versionRe := regexp.MustCompile(`\d+\.\d+\.\d+`)
@@ -221,9 +221,9 @@ func TestAPI_Options(t *testing.T) {
 		assert.Equal(t, options.Allow.OperationTypes[0], dps.OperationTransfer)
 	}
 
-	if assert.Len(t, options.Allow.Errors, errorCount) {
+	if assert.Len(t, options.Allow.Errors, wantErrorCount) {
 
-		for i := uint(0); i < errorCount; i++ {
+		for i := uint(0); i < wantErrorCount; i++ {
 
 			rosettaErr := options.Allow.Errors[i]
 

--- a/api/rosetta/data_network_integration_test.go
+++ b/api/rosetta/data_network_integration_test.go
@@ -44,7 +44,7 @@ func TestAPI_Status(t *testing.T) {
 		oldestBlockID = "d47b1bf7f37e192cf83d2bee3f6332b0d9b15c0aa7660d1e5322ea964667b333"
 	)
 
-	lastBlock := knownHeaders(425)
+	lastBlock := knownHeader(425)
 
 	request := rosetta.StatusRequest{
 		NetworkID: defaultNetwork(),
@@ -99,7 +99,8 @@ func TestAPI_StatusHandlesErrors(t *testing.T) {
 				http.StatusBadRequest,
 				configuration.ErrorInvalidFormat,
 				"blockchain identifier: blockchain field is missing",
-				nil),
+				nil,
+			),
 		},
 		{
 			name: "invalid blockchain",

--- a/api/rosetta/data_network_integration_test.go
+++ b/api/rosetta/data_network_integration_test.go
@@ -1,0 +1,559 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// +build integration
+
+package rosetta_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/optakt/flow-dps/api/rosetta"
+	"github.com/optakt/flow-dps/models/dps"
+	"github.com/optakt/flow-dps/rosetta/configuration"
+	"github.com/optakt/flow-dps/rosetta/identifier"
+)
+
+func TestAPI_Status(t *testing.T) {
+
+	db := setupDB(t)
+	api := setupAPI(t, db)
+
+	const (
+		lastHeight    = 425
+		oldestBlockID = "d47b1bf7f37e192cf83d2bee3f6332b0d9b15c0aa7660d1e5322ea964667b333"
+	)
+
+	lastBlock := knownHeaders(425)
+
+	tests := []struct {
+		name string
+
+		request rosetta.StatusRequest
+
+		checkError assert.ErrorAssertionFunc
+	}{
+		{
+			name: "network status",
+			request: rosetta.StatusRequest{
+				NetworkID: defaultNetwork(),
+			},
+		},
+		{
+			name: "missing blockchain",
+			request: rosetta.StatusRequest{
+				NetworkID: identifier.Network{
+					Blockchain: "",
+					Network:    dps.FlowTestnet.String(),
+				},
+			},
+
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"blockchain identifier: blockchain field is missing",
+				nil),
+		},
+		{
+			name: "invalid blockchain",
+			request: rosetta.StatusRequest{
+				NetworkID: identifier.Network{
+					Blockchain: invalidBlockchain,
+					Network:    dps.FlowTestnet.String(),
+				},
+			},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidNetwork,
+				fmt.Sprintf("invalid network identifier blockchain (have: %s, want: %s)", invalidBlockchain, dps.FlowBlockchain),
+				map[string]interface{}{
+					"blockchain": invalidBlockchain,
+					"network":    dps.FlowTestnet.String(),
+				},
+			),
+		},
+		{
+			name: "missing network",
+			request: rosetta.StatusRequest{
+				NetworkID: identifier.Network{
+					Blockchain: dps.FlowBlockchain,
+					Network:    "",
+				},
+			},
+
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"blockchain identifier: network field is missing",
+				nil),
+		},
+		{
+			name: "invalid network",
+			request: rosetta.StatusRequest{
+				NetworkID: identifier.Network{
+					Blockchain: dps.FlowBlockchain,
+					Network:    invalidNetwork,
+				},
+			},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidNetwork,
+				fmt.Sprintf("invalid network identifier network (have: %s, want: %s)", invalidNetwork, dps.FlowTestnet.String()),
+				map[string]interface{}{
+					"blockchain": dps.FlowBlockchain,
+					"network":    invalidNetwork,
+				},
+			),
+		},
+	}
+
+	for _, test := range tests {
+
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+
+			t.Parallel()
+
+			rec, ctx, err := setupRecorder(statusEndpoint, test.request)
+			require.NoError(t, err)
+
+			err = api.Status(ctx)
+
+			// if it's an error test case, verify we failed correctly
+			if test.checkError != nil {
+				test.checkError(t, err)
+				return
+			}
+
+			// verify nominal case
+			assert.NoError(t, err)
+
+			assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+
+			// unpack response
+			var status rosetta.StatusResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &status))
+
+			// verify current block
+			assert.Equal(t, status.CurrentBlockID.Index, lastBlock.Height)
+			assert.Equal(t, status.CurrentBlockID.Hash, lastBlock.ID().String())
+			assert.Equal(t, status.CurrentBlockTimestamp, rosettaTime(lastBlock.Timestamp))
+
+			// verify oldest block
+			assert.Equal(t, status.OldestBlockID.Hash, oldestBlockID)
+			// this is actually omitted from JSON, due to height being zero, and JSON having the 'omitempty' tag
+			assert.Equal(t, status.OldestBlockID.Index, uint64(0))
+		})
+	}
+}
+
+func TestAPI_Networks(t *testing.T) {
+
+	db := setupDB(t)
+	api := setupAPI(t, db)
+
+	// network request is basically an empty payload at the moment,
+	// there is a 'metadata' object that we're ignoring;
+	// but we can have the scaffolding here in case something changes
+
+	var netReq rosetta.NetworksRequest
+
+	rec, ctx, err := setupRecorder(listEndpoint, netReq)
+	require.NoError(t, err)
+
+	// execute the request
+	err = api.Networks(ctx)
+	assert.NoError(t, err)
+
+	var network rosetta.NetworksResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &network))
+
+	if assert.Len(t, network.NetworkIDs, 1) {
+		assert.Equal(t, network.NetworkIDs[0].Blockchain, dps.FlowBlockchain)
+		assert.Equal(t, network.NetworkIDs[0].Network, dps.FlowTestnet.String())
+	}
+}
+
+func TestAPI_Options(t *testing.T) {
+
+	db := setupDB(t)
+	api := setupAPI(t, db)
+
+	// verify version string is in the format of x.y.z
+	versionRe := regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+	const (
+		errorCount = 9
+	)
+
+	tests := []struct {
+		name string
+
+		request rosetta.OptionsRequest
+
+		checkError assert.ErrorAssertionFunc
+	}{
+		{
+			name: "nominal case",
+			request: rosetta.OptionsRequest{
+				NetworkID: defaultNetwork(),
+			},
+		},
+		{
+			name: "missing blockchain",
+			request: rosetta.OptionsRequest{
+				NetworkID: identifier.Network{
+					Blockchain: "",
+					Network:    dps.FlowTestnet.String(),
+				},
+			},
+
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"blockchain identifier: blockchain field is missing",
+				nil,
+			),
+		},
+		{
+			name: "invalid blockchain",
+			request: rosetta.OptionsRequest{
+				NetworkID: identifier.Network{
+					Blockchain: invalidBlockchain,
+					Network:    dps.FlowTestnet.String(),
+				},
+			},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidNetwork,
+				fmt.Sprintf("invalid network identifier blockchain (have: %s, want: %s)", invalidBlockchain, dps.FlowBlockchain),
+				map[string]interface{}{
+					"blockchain": invalidBlockchain,
+					"network":    dps.FlowTestnet.String(),
+				},
+			),
+		},
+		{
+			name: "missing network",
+			request: rosetta.OptionsRequest{
+				NetworkID: identifier.Network{
+					Blockchain: dps.FlowBlockchain,
+					Network:    "",
+				},
+			},
+
+			checkError: checkRosettaError(
+				http.StatusBadRequest,
+				configuration.ErrorInvalidFormat,
+				"blockchain identifier: network field is missing",
+				nil,
+			),
+		},
+		{
+			name: "invalid network",
+			request: rosetta.OptionsRequest{
+				NetworkID: identifier.Network{
+					Blockchain: dps.FlowBlockchain,
+					Network:    invalidNetwork,
+				},
+			},
+
+			checkError: checkRosettaError(
+				http.StatusUnprocessableEntity,
+				configuration.ErrorInvalidNetwork,
+				fmt.Sprintf("invalid network identifier network (have: %s, want: %s)", invalidNetwork, dps.FlowTestnet.String()),
+				map[string]interface{}{
+					"blockchain": dps.FlowBlockchain,
+					"network":    invalidNetwork,
+				},
+			),
+		},
+	}
+
+	for _, test := range tests {
+
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+
+			t.Parallel()
+
+			rec, ctx, err := setupRecorder(optionsEndpoint, test.request)
+			require.NoError(t, err)
+
+			err = api.Options(ctx)
+
+			// if it's an error test case, verify we failed correctly
+			if test.checkError != nil {
+				test.checkError(t, err)
+				return
+			}
+
+			// verify nominal case
+			assert.NoError(t, err)
+
+			assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+
+			var options rosetta.OptionsResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &options))
+
+			// verify the version info
+			// TODO: we're not currently doing exact match of the version, only of the format
+			// check - should we?
+			assert.Regexp(t, versionRe, options.Version.RosettaVersion)
+			assert.Regexp(t, versionRe, options.Version.NodeVersion)
+			assert.Regexp(t, versionRe, options.Version.MiddlewareVersion)
+
+			assert.True(t, options.Allow.HistoricalBalanceLookup)
+
+			if assert.Len(t, options.Allow.OperationStatuses, 1) {
+
+				status := options.Allow.OperationStatuses[0]
+				assert.Equal(t, status.Status, dps.StatusCompleted)
+				assert.True(t, status.Successful)
+			}
+
+			if assert.Len(t, options.Allow.OperationTypes, 1) {
+				assert.Equal(t, options.Allow.OperationTypes[0], dps.OperationTransfer)
+			}
+
+			if assert.Len(t, options.Allow.Errors, errorCount) {
+
+				for i := uint(0); i < errorCount; i++ {
+
+					rosettaErr := options.Allow.Errors[i]
+
+					expectedCode := i + 1 // error codes start from 1
+
+					assert.Equal(t, expectedCode, rosettaErr.Code)
+
+					switch expectedCode {
+
+					case 1:
+						assert.Equal(t, configuration.ErrorInternal.Message, rosettaErr.Message)
+						assert.Equal(t, configuration.ErrorInternal.Retriable, rosettaErr.Retriable)
+					case 2:
+						assert.Equal(t, configuration.ErrorInvalidFormat.Message, rosettaErr.Message)
+						assert.Equal(t, configuration.ErrorInvalidFormat.Retriable, rosettaErr.Retriable)
+					case 3:
+						assert.Equal(t, configuration.ErrorInvalidNetwork.Message, rosettaErr.Message)
+						assert.Equal(t, configuration.ErrorInvalidNetwork.Retriable, rosettaErr.Retriable)
+					case 4:
+						assert.Equal(t, configuration.ErrorInvalidAccount.Message, rosettaErr.Message)
+						assert.Equal(t, configuration.ErrorInvalidAccount.Retriable, rosettaErr.Retriable)
+					case 5:
+						assert.Equal(t, configuration.ErrorInvalidCurrency.Message, rosettaErr.Message)
+						assert.Equal(t, configuration.ErrorInvalidCurrency.Retriable, rosettaErr.Retriable)
+					case 6:
+						assert.Equal(t, configuration.ErrorInvalidBlock.Message, rosettaErr.Message)
+						assert.Equal(t, configuration.ErrorInvalidBlock.Retriable, rosettaErr.Retriable)
+					case 7:
+						assert.Equal(t, configuration.ErrorInvalidTransaction.Message, rosettaErr.Message)
+						assert.Equal(t, configuration.ErrorInvalidTransaction.Retriable, rosettaErr.Retriable)
+					case 8:
+						assert.Equal(t, configuration.ErrorUnknownBlock.Message, rosettaErr.Message)
+						assert.Equal(t, configuration.ErrorUnknownBlock.Retriable, rosettaErr.Retriable)
+					case 9:
+						assert.Equal(t, configuration.ErrorUnknownCurrency.Message, rosettaErr.Message)
+						assert.Equal(t, configuration.ErrorUnknownCurrency.Retriable, rosettaErr.Retriable)
+
+					default:
+						t.Errorf("unknown rosetta error received: (code: %v, message: '%v', retriable: %v", rosettaErr.Code, rosettaErr.Message, rosettaErr.Retriable)
+					}
+				}
+			}
+		})
+	}
+
+}
+
+func TestAPI_StatusHandlerMalformedRequest(t *testing.T) {
+
+	db := setupDB(t)
+	api := setupAPI(t, db)
+
+	const (
+		// wrong type for 'network' field
+		wrongFieldType = `{
+			"network_identifier": {
+				"blockchain": "flow",
+				"network": 99
+			}
+		}`
+
+		// malformed JSON - unclosed bracket
+		unclosedBracket = `{
+			"network_identifier": {
+				"blockchain": "flow",
+				"network": "flow-testnet"
+			}`
+
+		validPayload = `{
+			"network_identifier": {
+				"blockchain": "flow",
+				"network": "flow-testnet"
+			}
+		}`
+	)
+
+	tests := []struct {
+		name string
+
+		payload []byte
+
+		prepare func(*http.Request)
+	}{
+		{
+			name:    "invalid status input types",
+			payload: []byte(wrongFieldType),
+			prepare: func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			},
+		},
+		{
+			name:    "invalid status json format",
+			payload: []byte(unclosedBracket),
+			prepare: func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			},
+		},
+		{
+			name:    "valid status payload with no MIME type",
+			payload: []byte(validPayload),
+			prepare: func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, "")
+			},
+		},
+	}
+
+	for _, test := range tests {
+
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+
+			t.Parallel()
+
+			_, ctx, err := setupRecorder(statusEndpoint, test.payload, test.prepare)
+			require.NoError(t, err)
+
+			// execute the request
+			err = api.Status(ctx)
+			assert.Error(t, err)
+
+			echoErr, ok := err.(*echo.HTTPError)
+			require.True(t, ok)
+
+			assert.Equal(t, http.StatusBadRequest, echoErr.Code)
+			gotErr, ok := echoErr.Message.(rosetta.Error)
+			require.True(t, ok)
+
+			assert.Equal(t, configuration.ErrorInvalidFormat, gotErr.ErrorDefinition)
+		})
+	}
+}
+
+func TestAPI_OptionsHandlesMalformedRequest(t *testing.T) {
+
+	db := setupDB(t)
+	api := setupAPI(t, db)
+
+	const (
+		// wrong type for 'network' field
+		wrongFieldType = `{
+			"network_identifier": {
+				"blockchain": "flow",
+				"network": 99
+			}
+		}`
+
+		// malformed JSON - unclosed bracket
+		unclosedBracket = `{
+			"network_identifier": {
+				"blockchain": "flow",
+				"network": "flow-testnet"
+			}`
+
+		validPayload = `{
+			"network_identifier": {
+				"blockchain": "flow",
+				"network": "flow-testnet"
+			}
+		}`
+	)
+
+	tests := []struct {
+		name string
+
+		payload []byte
+
+		prepare func(*http.Request)
+	}{
+		{
+			name:    "invalid options input types",
+			payload: []byte(wrongFieldType),
+			prepare: func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			},
+		},
+		{
+			name:    "invalid options json format",
+			payload: []byte(unclosedBracket),
+			prepare: func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			},
+		},
+		{
+			name:    "valid options payload with no MIME type",
+			payload: []byte(validPayload),
+			prepare: func(req *http.Request) {
+				req.Header.Set(echo.HeaderContentType, "")
+			},
+		},
+	}
+
+	for _, test := range tests {
+
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+
+			t.Parallel()
+
+			_, ctx, err := setupRecorder(optionsEndpoint, test.payload, test.prepare)
+			require.NoError(t, err)
+
+			// execute the request
+			err = api.Options(ctx)
+			assert.Error(t, err)
+
+			echoErr, ok := err.(*echo.HTTPError)
+			require.True(t, ok)
+
+			assert.Equal(t, http.StatusBadRequest, echoErr.Code)
+			gotErr, ok := echoErr.Message.(rosetta.Error)
+			require.True(t, ok)
+
+			assert.Equal(t, configuration.ErrorInvalidFormat, gotErr.ErrorDefinition)
+		})
+	}
+}

--- a/api/rosetta/data_transaction_integration_test.go
+++ b/api/rosetta/data_transaction_integration_test.go
@@ -41,9 +41,9 @@ func TestAPI_Transaction(t *testing.T) {
 	api := setupAPI(t, db)
 
 	var (
-		firstHeader      = knownHeaders(44)
-		multipleTxHeader = knownHeaders(165)
-		lastHeader       = knownHeaders(181)
+		firstHeader      = knownHeader(44)
+		multipleTxHeader = knownHeader(165)
+		lastHeader       = knownHeader(181)
 
 		// two transactions in a single block
 		midBlockTxs = []string{
@@ -354,7 +354,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 			checkErr: checkRosettaError(
 				http.StatusUnprocessableEntity,
 				configuration.ErrorInvalidBlock,
-				fmt.Sprintf("block hash does not match known hash for height (known: %s)", knownHeaders(44).ID().String()),
+				fmt.Sprintf("block hash does not match known hash for height (known: %s)", knownHeader(44).ID().String()),
 				map[string]interface{}{
 					"index": uint64(44),
 					"hash":  testBlockHash,

--- a/api/rosetta/data_transaction_integration_test.go
+++ b/api/rosetta/data_transaction_integration_test.go
@@ -18,7 +18,6 @@ package rosetta_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -162,12 +161,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 			name:    "empty transaction request",
 			request: rosetta.TransactionRequest{},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: blockchain field is empty",
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "missing blockchain name",
@@ -180,12 +174,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				TransactionID: testTx,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: blockchain field is empty",
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid blockchain name",
@@ -198,15 +187,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				TransactionID: testTx,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidNetwork,
-				fmt.Sprintf("invalid network identifier blockchain (have: %s, want: %s)", invalidBlockchain, dps.FlowBlockchain),
-				map[string]interface{}{
-					"blockchain": invalidBlockchain,
-					"network":    dps.FlowTestnet.String(),
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidNetwork),
 		},
 		{
 			name: "missing network name",
@@ -219,12 +200,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				TransactionID: testTx,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"blockchain identifier: network field is empty",
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid network name",
@@ -237,15 +213,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				TransactionID: testTx,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidNetwork,
-				fmt.Sprintf("invalid network identifier network (have: %s, want: %s)", invalidNetwork, dps.FlowTestnet.String()),
-				map[string]interface{}{
-					"blockchain": dps.FlowBlockchain,
-					"network":    invalidNetwork,
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidNetwork),
 		},
 		{
 			name: "missing block height and hash",
@@ -258,12 +226,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				TransactionID: testTx,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"block identifier: at least one of hash or index is required",
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid length of block id",
@@ -276,12 +239,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				TransactionID: testTx,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				fmt.Sprintf("block identifier: hash field has wrong length (have: %d, want: %d)", len(trimmedBlockHash), validBlockHashLen),
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "missing block height",
@@ -292,12 +250,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				},
 				TransactionID: testTx,
 			},
-			checkErr: checkRosettaError(
-				http.StatusInternalServerError,
-				configuration.ErrorInternal,
-				"could not validate block: block access with hash currently not supported",
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusInternalServerError, configuration.ErrorInternal),
 		},
 		{
 			name: "invalid block hash",
@@ -310,15 +263,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				TransactionID: testTx,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidBlock,
-				"block hash is not a valid hex-encoded string",
-				map[string]interface{}{
-					"index": uint64(testHeight),
-					"hash":  invalidBlockHash,
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidBlock),
 		},
 		{
 			name: "unknown block",
@@ -330,15 +275,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				TransactionID: testTx,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorUnknownBlock,
-				fmt.Sprintf("block index is above last indexed block (last: %d)", lastHeight),
-				map[string]interface{}{
-					"index": uint64(lastHeight + 1),
-					"hash":  "",
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorUnknownBlock),
 		},
 		{
 			name: "mismatched block height and hash",
@@ -351,15 +288,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				TransactionID: testTx,
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidBlock,
-				fmt.Sprintf("block hash does not match known hash for height (known: %s)", knownHeader(44).ID().String()),
-				map[string]interface{}{
-					"index": uint64(44),
-					"hash":  testBlockHash,
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidBlock),
 		},
 		{
 			name: "missing transaction id",
@@ -371,12 +300,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				"transaction identifier: hash field is empty",
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "missing transaction id",
@@ -388,12 +312,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusBadRequest,
-				configuration.ErrorInvalidFormat,
-				fmt.Sprintf("transaction identifier: hash field has wrong length (have: %d, want: %d)", len(trimmedTxHash), validBlockHashLen),
-				nil,
-			),
+			checkErr: checkRosettaError(http.StatusBadRequest, configuration.ErrorInvalidFormat),
 		},
 		{
 			name: "invalid transaction id",
@@ -405,14 +324,7 @@ func TestAPI_TransactionHandlesErrors(t *testing.T) {
 				},
 			},
 
-			checkErr: checkRosettaError(
-				http.StatusUnprocessableEntity,
-				configuration.ErrorInvalidTransaction,
-				"transaction hash is not a valid hex-encoded string",
-				map[string]interface{}{
-					"hash": invalidTxHash,
-				},
-			),
+			checkErr: checkRosettaError(http.StatusUnprocessableEntity, configuration.ErrorInvalidTransaction),
 		},
 		// TODO: add - transaction that has no events/transfers
 		// TODO: add - transaction that does not exist in a block


### PR DESCRIPTION
## Goal of this PR

This PR adds integration tests for the remaining three Rosetta endpoints.
It also includes slight refactors to the previous integrations tests - mainly the HTTP request execution (setup is offloaded to the `setupRecorder` helper) and the rosetta error verification (`checkRosettaError`).


## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date