### PR TITLE
FSM: fix clean shutdown of mapper

### DIFF
--- a/models/dps/errors.go
+++ b/models/dps/errors.go
@@ -19,6 +19,7 @@ import (
 )
 
 var (
-	ErrFinished = errors.New("finished")
-	ErrTimeout  = errors.New("timeout")
+	ErrFinished    = errors.New("finished")
+	ErrTimeout     = errors.New("timeout")
+	ErrUnavailable = errors.New("unavailable")
 )

--- a/service/chain/disk.go
+++ b/service/chain/disk.go
@@ -17,23 +17,27 @@ package chain
 import (
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/optakt/flow-dps/models/dps"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
-
-	"github.com/optakt/flow-dps/models/dps"
 )
 
 type Disk struct {
-	db *badger.DB
+	db      *badger.DB
+	height  uint64
+	blockID flow.Identifier
 }
 
 func FromDisk(db *badger.DB) *Disk {
 	d := Disk{
-		db: db,
+		db:      db,
+		height:  math.MaxUint64,
+		blockID: flow.ZeroID,
 	}
 
 	return &d
@@ -48,14 +52,30 @@ func (d *Disk) Root() (uint64, error) {
 	return height, nil
 }
 
-func (d *Disk) Header(height uint64) (*flow.Header, error) {
-	var blockID flow.Identifier
-	err := operation.LookupBlockHeight(height, &blockID)(d.db.NewTransaction(false))
+func (d *Disk) Commit(height uint64) (flow.StateCommitment, error) {
+
+	blockID, err := d.block(height)
 	if errors.Is(err, storage.ErrNotFound) {
-		return nil, dps.ErrFinished
+		return flow.StateCommitment{}, dps.ErrFinished
 	}
 	if err != nil {
-		return nil, fmt.Errorf("could not look up block: %w", err)
+		return flow.StateCommitment{}, fmt.Errorf("could not get block for height: %w", err)
+	}
+
+	var commit flow.StateCommitment
+	err = operation.LookupStateCommitment(blockID, &commit)(d.db.NewTransaction(false))
+	if err != nil {
+		return flow.StateCommitment{}, fmt.Errorf("could not look up commit: %w", err)
+	}
+
+	return commit, nil
+}
+
+func (d *Disk) Header(height uint64) (*flow.Header, error) {
+
+	blockID, err := d.block(height)
+	if err != nil {
+		return nil, fmt.Errorf("could not get block for height: %w", err)
 	}
 
 	var header flow.Header
@@ -66,26 +86,11 @@ func (d *Disk) Header(height uint64) (*flow.Header, error) {
 	return &header, nil
 }
 
-func (d *Disk) Commit(height uint64) (flow.StateCommitment, error) {
-	var blockID flow.Identifier
-	err := operation.LookupBlockHeight(height, &blockID)(d.db.NewTransaction(false))
-	if errors.Is(err, storage.ErrNotFound) {
-		return flow.StateCommitment{}, dps.ErrFinished
-	}
-
-	var commit flow.StateCommitment
-	err = operation.LookupStateCommitment(blockID, &commit)(d.db.NewTransaction(false))
-	if errors.Is(err, storage.ErrNotFound) {
-		return flow.StateCommitment{}, dps.ErrFinished
-	}
-	return commit, nil
-}
-
 func (d *Disk) Events(height uint64) ([]flow.Event, error) {
-	var blockID flow.Identifier
-	err := operation.LookupBlockHeight(height, &blockID)(d.db.NewTransaction(false))
-	if errors.Is(err, storage.ErrNotFound) {
-		return nil, dps.ErrFinished
+
+	blockID, err := d.block(height)
+	if err != nil {
+		return nil, fmt.Errorf("could not get block for height: %w", err)
 	}
 
 	var events []flow.Event
@@ -98,28 +103,49 @@ func (d *Disk) Events(height uint64) ([]flow.Event, error) {
 }
 
 func (d *Disk) Transactions(height uint64) ([]*flow.TransactionBody, error) {
-	var blockID flow.Identifier
-	err := operation.LookupBlockHeight(height, &blockID)(d.db.NewTransaction(false))
-	if errors.Is(err, storage.ErrNotFound) {
-		return nil, dps.ErrFinished
+
+	blockID, err := d.block(height)
+	if err != nil {
+		return nil, fmt.Errorf("could not get block for height: %w", err)
 	}
 
 	var results []flow.TransactionResult
 	err = operation.LookupTransactionResultsByBlockID(blockID, &results)(d.db.NewTransaction(false))
-	if errors.Is(err, storage.ErrNotFound) {
-		return nil, dps.ErrFinished
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve results: %w", err)
 	}
 
 	transactions := make([]*flow.TransactionBody, 0, len(results))
 	for _, result := range results {
 		var transaction flow.TransactionBody
 		err := operation.RetrieveTransaction(result.TransactionID, &transaction)(d.db.NewTransaction(false))
-		if errors.Is(err, storage.ErrNotFound) {
-			return nil, dps.ErrFinished
+		if err != nil {
+			return nil, fmt.Errorf("could not retrieve transactions: %w", err)
 		}
 
 		transactions = append(transactions, &transaction)
 	}
 
 	return transactions, nil
+}
+
+func (d *Disk) block(height uint64) (flow.Identifier, error) {
+
+	if d.height == height {
+		return d.blockID, nil
+	}
+
+	// The protocol state maps everything by block ID. However, finalized blocks
+	// are unambiguously available by height, so we can look up which block ID
+	// corresponds to the desired height.
+	var blockID flow.Identifier
+	err := operation.LookupBlockHeight(height, &blockID)(d.db.NewTransaction(false))
+	if err != nil {
+		return flow.ZeroID, fmt.Errorf("could not look up block: %w", err)
+	}
+
+	d.height = height
+	d.blockID = blockID
+
+	return blockID, nil
 }

--- a/service/chain/disk.go
+++ b/service/chain/disk.go
@@ -20,11 +20,12 @@ import (
 	"math"
 
 	"github.com/dgraph-io/badger/v2"
-	"github.com/optakt/flow-dps/models/dps"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
+
+	"github.com/optakt/flow-dps/models/dps"
 )
 
 type Disk struct {

--- a/service/feeder/disk.go
+++ b/service/feeder/disk.go
@@ -56,7 +56,7 @@ func (d *Disk) Update() (*ledger.TrieUpdate, error) {
 			return nil, fmt.Errorf("could not read next record: %w", err)
 		}
 		if !next {
-			return nil, dps.ErrFinished
+			return nil, dps.ErrUnavailable
 		}
 		record := d.reader.Record()
 		operation, _, update, err := wal.Decode(record)

--- a/service/mapper/fsm.go
+++ b/service/mapper/fsm.go
@@ -16,8 +16,11 @@ package mapper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/optakt/flow-dps/models/dps"
 )
 
 type FSM struct {
@@ -56,6 +59,9 @@ func (f *FSM) Run() error {
 			return fmt.Errorf("could not find transition for status (%d)", f.state.status)
 		}
 		err := transition(f.state)
+		if errors.Is(err, dps.ErrFinished) {
+			return nil
+		}
 		if err != nil {
 			return fmt.Errorf("could not apply transition to state: %w", err)
 		}


### PR DESCRIPTION
## Goal of this PR

Essentially, the current FSM code that was running the transitions didn't check if we have a `dps.ErrFinished` error to cleanly shut down. This PR addresses that. Additionally, I made the following improvements:

- Every finalized block should be executed on a spork, in principle. This means the `LedgerWAL`, and thus the feeder, should have all `ledger.TrieUpdate`s for every finalized block. Or, in other words, we should error explicitly if we reach the end of trie updates before reaching the end of finalized blocks. I changed it to `dps.ErrUnavailable` instead.

- The first thing we load for a new height is the state commitment. Every time we load something for a height from the chain, we do a lookup for the block ID corresponding to that height. If that look up fails, it means the block is not finalized. In other words, we only need to check for `badger.ErrKeyNotFound` on the commit loading for a new height, and return `dps.ErrFinished` there. All other errors can remain explicit.

- Last but not least, we currently load the block ID corresponding to the height from disk every time. This should be taken care of by the Badger cache, but I added a simple cache to the on-disk chain that will just always cache the block ID for the last requested height. That way, we can make 4 requests less to Badger.

- Also important: we only checked for `badger.ErrKeyNotFound` on some of the chain methods, where it was not needed. Not only that, we didn't even check if we had another kind of error! That was a pretty solid bug, forgetting to check an error xD.

Fixes #244.

## Checklist

- [ ] Is on the right branch
- [ ] Documentation is up-to-date
- [ ] Tests are up-to-date