### PR TITLE
Fix re-use of byte slices in feeder decoding

### DIFF
--- a/service/feeder/clone.go
+++ b/service/feeder/clone.go
@@ -27,7 +27,7 @@ func clone(update *ledger.TrieUpdate) *ledger.TrieUpdate {
 	for _, path := range update.Paths {
 		var dup ledger.Path
 		copy(dup[:], path[:])
-		paths = append(paths, path)
+		paths = append(paths, dup)
 	}
 
 	payloads := make([]*ledger.Payload, 0, len(update.Payloads))

--- a/service/feeder/clone.go
+++ b/service/feeder/clone.go
@@ -12,19 +12,35 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package mapper
+package feeder
 
 import (
 	"github.com/onflow/flow-go/ledger"
-	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
-	"github.com/onflow/flow-go/model/flow"
 )
 
-type Forest interface {
-	Save(tree *trie.MTrie, paths []ledger.Path, parent flow.StateCommitment)
-	Has(commit flow.StateCommitment) bool
-	Tree(commit flow.StateCommitment) (*trie.MTrie, bool)
-	Paths(commit flow.StateCommitment) ([]ledger.Path, bool)
-	Parent(commit flow.StateCommitment) (flow.StateCommitment, bool)
-	Reset(finalized flow.StateCommitment)
+func clone(update *ledger.TrieUpdate) *ledger.TrieUpdate {
+
+	var hash ledger.RootHash
+	copy(hash[:], update.RootHash[:])
+
+	paths := make([]ledger.Path, 0, len(update.Paths))
+	for _, path := range update.Paths {
+		var dup ledger.Path
+		copy(dup[:], path[:])
+		paths = append(paths, path)
+	}
+
+	payloads := make([]*ledger.Payload, 0, len(update.Payloads))
+	for _, payload := range update.Payloads {
+		dup := payload.DeepCopy()
+		payloads = append(payloads, dup)
+	}
+
+	dup := ledger.TrieUpdate{
+		RootHash: hash,
+		Paths:    paths,
+		Payloads: payloads,
+	}
+
+	return &dup
 }

--- a/service/feeder/disk.go
+++ b/service/feeder/disk.go
@@ -67,6 +67,10 @@ func (d *Disk) Update() (*ledger.TrieUpdate, error) {
 			continue
 		}
 
+		// However, we need to make sure that all slices are copied, because the
+		// decode function will reuse the underlying slices later.
+		update = clone(update)
+
 		return update, nil
 	}
 }

--- a/service/forest/forest.go
+++ b/service/forest/forest.go
@@ -83,7 +83,3 @@ func (f *Forest) Reset(finalized flow.StateCommitment) {
 		}
 	}
 }
-
-func (f *Forest) Size() uint {
-	return uint(len(f.steps))
-}


### PR DESCRIPTION
## Goal of this PR

This PR makes sure the feeder deep-copies the `ledger.TrieUpdate` after decoding. This fixes the issue where the responsibility lies and should make any consumer of the feeder safe from bugs due to weird behaviour.

Fixes #257 (hopefully).

## Checklist

- [x] Is on the right branch