### PR TITLE
Rosetta: Adding genesis block

### DIFF
--- a/api/rosetta/data_network_integration_test.go
+++ b/api/rosetta/data_network_integration_test.go
@@ -69,6 +69,13 @@ func TestAPI_Status(t *testing.T) {
 	if assert.NotNil(t, oldestHeight) {
 		assert.Equal(t, *oldestHeight, uint64(0))
 	}
+
+	assert.Equal(t, status.GenesisBlockID.Hash, oldestBlockID)
+
+	genesisBlockHeight := status.GenesisBlockID.Index
+	if assert.NotNil(t, genesisBlockHeight) {
+		assert.Equal(t, *genesisBlockHeight, uint64(0))
+	}
 }
 
 func TestAPI_StatusHandlesErrors(t *testing.T) {

--- a/api/rosetta/status.go
+++ b/api/rosetta/status.go
@@ -36,6 +36,7 @@ type StatusResponse struct {
 	CurrentBlockID        identifier.Block `json:"current_block_identifier"`
 	CurrentBlockTimestamp int64            `json:"current_block_timestamp"`
 	OldestBlockID         identifier.Block `json:"oldest_block_identifier"`
+	GenesisBlockID        identifier.Block `json:"genesis_block_identifier"`
 }
 
 // Status implements the /network/status endpoint of the Rosetta Data API.
@@ -77,6 +78,7 @@ func (d *Data) Status(ctx echo.Context) error {
 		CurrentBlockID:        current,
 		CurrentBlockTimestamp: timestamp.UnixNano() / 1_000_000,
 		OldestBlockID:         oldest,
+		GenesisBlockID:        oldest,
 	}
 
 	// TODO: Implement genesis block return

--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -231,19 +231,19 @@ func (r *Retriever) Block(id identifier.Block) (*object.Block, []identifier.Tran
 		count++
 	}
 
-	h := header.Height - 1
 	parent := identifier.Block{
-		Index: &h,
-		Hash:  header.ParentID.String(),
+		Index: &header.Height,
+		Hash:  header.ID().String(),
 	}
 
 	// Rosetta spec notes that for genesis block, it is recommended to use the
 	// genesis block identifier also for the parent block identifier.
 	// See https://www.rosetta-api.org/docs/common_mistakes.html#malformed-genesis-block
-	if header.Height == 0 {
+	if header.Height > 0 {
+		h := header.Height - 1
 		parent = identifier.Block{
-			Index: &header.Height,
-			Hash:  header.ID().String(),
+			Index: &h,
+			Hash:  header.ParentID.String(),
 		}
 	}
 


### PR DESCRIPTION
## Goal of this PR

Fixes #229.

This PR adds the information about the genesis block as part of the `/network/status` response.
It also tweaks the output of the `/block` endpoint, as I spotted in the Rosetta docs that, for the genesis block, the index/hash of the block should be also specified as the parent block index/hash ([documentation link](https://www.rosetta-api.org/docs/common_mistakes.html#malformed-genesis-block)).
Integration tests were also updated to reflect that fact.

## Checklist

- [x] Is on the right branch
- [x] ~Documentation is up-to-date~
- [x] Tests are up-to-date