### PR TITLE
Executor: run cadence scripts via DPS server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /cmd/flow-dps-indexer/flow-dps-indexer
 /cmd/flow-rosetta-server/flow-rosetta-server
 /cmd/flow-dps-server/flow-dps-server
+/cmd/flow-dps-executor/flow-dps-executor
 /data/
 /index/
 /trie/

--- a/cmd/flow-dps-executor/README.md
+++ b/cmd/flow-dps-executor/README.md
@@ -1,0 +1,173 @@
+# Flow DPS Executor
+
+## Description
+
+The Flow DPS Executor provides access to Flow DPS Server's index through a REST API.
+It can be used to execute Cadence scripts at an arbitrary block height of a fork.
+It uses the Flow DPS Server's GRPC API as the backend to query the required data.
+
+## Running the Executable
+
+```sh
+Usage of flow-dps-executor:
+  -a, --api string     host for GRPC API server
+  -l, --level string   log output level (default "info")
+  -p, --port uint16    port to host Executor API on (default 8080)
+```
+
+## Usage over HTTP
+
+The Flow DPS Executor accepts POST requests at the `/execute` endpoint.
+Example of a correct HTTP request payload sent to the Executor is shown below:
+
+```json
+{
+    "height": 10,
+    "script": "script text",
+    "arguments": [
+        "type1(value1)",
+        "type2(value2)",
+        "type3(value3)" 
+    ]
+}
+```
+
+If the provided script expects no arguments, the `arguments` string array can be ommitted.
+Example of an HTTP response payload sent by the Executor after successful script execution is shown below:
+
+```json
+{
+    "height": 10,
+    "script": "script text",
+    "arguments": [
+        "type1(value1)",
+        "type2(value2)",
+        "type3(value3)" 
+    ],
+    "result": <script result>
+}
+```
+
+## Examples
+
+### Running a Script With No Arguments
+
+The example below describes an interaction where a simple script returning a single value is executed.
+
+Script text:
+
+```
+// This script returns a hardcoded value.
+// It can be used to showcase execution of scripts without arguments.
+
+pub fun main(): UFix64 {
+
+    let x: UFix64 = 17.0
+    return x
+}
+```
+
+Example of a POST request payload to execute the shown script:
+
+```json
+{
+    "height": 14,
+    "script": "pub fun main(): UFix64 {\n        let x: UFix64 = 17.0\n        return x\n    }"
+}
+```
+
+Example of the response:
+
+```json
+{
+    "height": 14,
+    "script": "pub fun main(): UFix64 {\n        let x: UFix64 = 17.0\n        return x\n    }",
+    "result": 1700000000
+}
+```
+### Runinning a Script With Arguments
+
+Script example:
+
+```
+// This script accepts a single numeric argument, and returns that argument increased by a 1000.
+// This script can be used to showcase execution of a script with arguments. 
+
+pub fun main(value: UFix64): UFix64 {
+
+    let x: UFix64 = 1000.0 + value
+    return x
+}
+```
+
+Example of a POST request payload to execute the shown script:
+
+```json
+{
+    "height": 45,
+    "script": "pub fun main(value: UFix64): UFix64 {\n        let x: UFix64 = 1000.0 + value\n        return x\n    }",
+    "arguments": [
+        "UFix64(17.0)"
+    ]
+}
+```
+
+Example of the response:
+
+```json
+{
+    "height": 45,
+    "script": "pub fun main(value: UFix64): UFix64 {\n        let x: UFix64 = 1000.0 + value\n        return x\n    }",
+    "arguments": [
+        "UFix64(17.0)"
+    ],
+    "result": 101700000000
+}
+```
+### Real World Example - Return the Balance of an Account
+
+Script text:
+
+```
+// This script reads the balance field of an account's FlowToken Balance
+
+import FungibleToken from 0x9a0766d93b6608b7
+import FlowToken from 0x7e60df042a9c0868
+
+pub fun main(account: Address): UFix64 {
+
+    let vaultRef = getAccount(account)
+        .getCapability(/public/flowTokenBalance)
+        .borrow<&FlowToken.Vault{FungibleToken.Balance}>()
+        ?? panic("Could not borrow Balance reference to the Vault")
+
+    return vaultRef.balance
+}
+```
+
+Example of a POST request payload to execute the shown script:
+
+```json
+{
+    "height": 425,
+    "script": "<script text trimmed for brevity>",
+    "arguments": [
+        "Address(754aed9de6197641)"
+    ]
+}
+```
+
+Example of the response:
+
+```json
+{
+    "height": 425,
+    "script": "<script text trimmed for brevity>",
+    "arguments": [
+        "Address(754aed9de6197641)"
+        ],
+    "result": 10000100002
+}
+```
+
+Changing the `height` argument would retrieve the balance at a different point in chain history.

--- a/cmd/flow-dps-executor/main.go
+++ b/cmd/flow-dps-executor/main.go
@@ -1,0 +1,146 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+	"github.com/spf13/pflag"
+	"github.com/ziflex/lecho/v2"
+	"google.golang.org/grpc"
+
+	api "github.com/optakt/flow-dps/api/dps"
+	"github.com/optakt/flow-dps/codec/zbor"
+	"github.com/optakt/flow-dps/executor"
+	"github.com/optakt/flow-dps/invoker"
+)
+
+const (
+	success = 0
+	failure = 1
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+
+	// Signal catching for clean shutdown.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+
+	var (
+		flagAPI   string
+		flagCache uint64
+		flagLevel string
+		flagPort  uint16
+	)
+
+	pflag.StringVarP(&flagAPI, "api", "a", "127.0.0.1:5005", "host for GRPC API server")
+	pflag.Uint64VarP(&flagCache, "cache", "e", uint64(datasize.GB), "maximum cache size for register reads in bytes")
+	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
+	pflag.Uint16VarP(&flagPort, "port", "p", 8080, "port to host Executor API on")
+
+	pflag.Parse()
+
+	// Logger initialization.
+	zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
+	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.DebugLevel)
+	level, err := zerolog.ParseLevel(flagLevel)
+	if err != nil {
+		log.Error().Str("level", flagLevel).Err(err).Msg("could not parse log level")
+		return failure
+	}
+	log = log.Level(level)
+	elog := lecho.From(log)
+
+	zerolog.SetGlobalLevel(level)
+
+	// Initialize the API client.
+	conn, err := grpc.Dial(flagAPI, grpc.WithInsecure())
+	if err != nil {
+		log.Error().Str("api", flagAPI).Err(err).Msg("could not dial API host")
+		return failure
+	}
+	defer conn.Close()
+
+	// Initialize storage library.
+	codec, err := zbor.NewCodec()
+	if err != nil {
+		log.Error().Err(err).Msg("could not initialize storage codec")
+		return failure
+	}
+
+	// Execute the script using remote lookup and read.
+	client := api.NewAPIClient(conn)
+	index := api.IndexFromAPI(client, codec)
+	invoker, err := invoker.New(index, invoker.WithCacheSize(flagCache))
+	if err != nil {
+		log.Error().Err(err).Msg("could not initialize invoker")
+		return failure
+	}
+
+	executor := executor.New(invoker)
+
+	server := echo.New()
+	server.HideBanner = true
+	server.HidePort = true
+	server.Logger = elog
+	server.Use(lecho.Middleware(lecho.Config{Logger: elog}))
+	server.POST("/execute", executor.Script)
+
+	// This section launches the main executing components in their own
+	// goroutine, so they can run concurrently. Afterwards, we wait for an
+	// interrupt signal in order to proceed with the next section.
+	done := make(chan struct{})
+	failed := make(chan struct{})
+	go func() {
+		log.Info().Msg("Flow Executor starting")
+		err := server.Start(fmt.Sprint(":", flagPort))
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Warn().Err(err).Msg("Flow Executor failed")
+			close(failed)
+		} else {
+			close(done)
+		}
+		log.Info().Msg("Flow Executor stopped")
+	}()
+
+	select {
+	case <-sig:
+		log.Info().Msg("Flow Executor stopping")
+	case <-done:
+		log.Info().Msg("Flow Executor done")
+	case <-failed:
+		log.Warn().Msg("Flow Executor aborted")
+		return failure
+	}
+	go func() {
+		<-sig
+		log.Warn().Msg("forcing exit")
+		os.Exit(1)
+	}()
+
+	return success
+}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,0 +1,28 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package executor
+
+type Executor struct {
+	invoker Invoker
+}
+
+func New(invoker Invoker) *Executor {
+
+	e := Executor{
+		invoker: invoker,
+	}
+
+	return &e
+}

--- a/executor/http.go
+++ b/executor/http.go
@@ -1,0 +1,42 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package executor
+
+import (
+	"fmt"
+
+	"github.com/labstack/echo/v4"
+)
+
+type httpError struct {
+	Message string `json:"message"`
+	Err     string `json:"error,omitempty"`
+}
+
+func (e httpError) Error() string {
+	if e.Err == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%v (err: %v)", e.Message, e.Err)
+}
+
+func newHTTPError(code int, message string, err error) *echo.HTTPError {
+	e := httpError{
+		Message: message,
+		Err:     err.Error(),
+	}
+
+	return echo.NewHTTPError(code, e)
+}

--- a/executor/invoker.go
+++ b/executor/invoker.go
@@ -1,0 +1,23 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package executor
+
+import (
+	"github.com/onflow/cadence"
+)
+
+type Invoker interface {
+	Script(height uint64, script []byte, parameters []cadence.Value) (cadence.Value, error)
+}

--- a/executor/script.go
+++ b/executor/script.go
@@ -1,0 +1,92 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package executor
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/onflow/cadence"
+
+	"github.com/optakt/flow-dps/models/convert"
+)
+
+// ScriptRequest describes the input data needed for script execution.
+type ScriptRequest struct {
+	Height    *uint64  `json:"height"`
+	Script    string   `json:"script"`
+	Arguments []string `json:"arguments"`
+}
+
+// ScriptResponse describes the output data of the script execution.
+// The response includes all of the input arguments, as well as the
+// execution result.
+type ScriptResponse struct {
+	Height    uint64          `json:"height"`
+	Script    string          `json:"script"`
+	Arguments []string        `json:"arguments,omitempty"`
+	Result    json.RawMessage `json:"result"`
+}
+
+// Script endpoint handles execution of Cadence scripts at arbitrary heights.
+func (e *Executor) Script(ctx echo.Context) error {
+
+	// Unpack request data.
+	var script ScriptRequest
+	err := ctx.Bind(&script)
+	if err != nil {
+		return newHTTPError(http.StatusBadRequest, "could not unmarshal request", err)
+	}
+
+	// Validate mandatory arguments - height and script text are required.
+	if script.Height == nil || script.Script == "" {
+		return newHTTPError(http.StatusBadRequest, "missing height or script text", nil)
+	}
+
+	// Convert the script arguments.
+	args := make([]cadence.Value, 0, len(script.Arguments))
+	for _, arg := range script.Arguments {
+		val, err := convert.ParseCadenceArgument(arg)
+		if err != nil {
+			return newHTTPError(http.StatusBadRequest, "could not parse cadence value", err)
+		}
+
+		args = append(args, val)
+	}
+
+	// Execute the script.
+	res, err := e.invoker.Script(*script.Height, []byte(script.Script), args)
+	if err != nil {
+		return newHTTPError(http.StatusInternalServerError, "could not execute script", err)
+	}
+
+	// Prepare and send the response.
+
+	payload, err := json.Marshal(res)
+	if err != nil {
+		return newHTTPError(http.StatusInternalServerError, "could not marshal response", err)
+	}
+
+	out := ScriptResponse{
+		Height:    *script.Height,
+		Script:    script.Script,
+		Arguments: script.Arguments,
+		Result:    payload,
+	}
+
+	return ctx.JSON(http.StatusOK, out)
+}


### PR DESCRIPTION
## Goal of this PR

This PR is still a bit of a work in progress since there's a few questions I'm having second thoughts about.

This PR introduces `flow-dps-executor`, a new binary somewhat similar to `flow-dps-client`, in the fact that is used to execute Cadence scripts at an arbitrary block height. The differences are that here the majority of the  workload regarding script execution is done on the DPS server.


## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] ~Tests are up-to-date~