### PR TITLE
Indexer: allow skipping of checkpoint registers

### DIFF
--- a/cmd/flow-dps-indexer/README.md
+++ b/cmd/flow-dps-indexer/README.md
@@ -24,6 +24,7 @@ Usage of flow-dps-indexer:
   -l, --level string                log output level (default "info")
   -m, --metrics                     enable metrics collection and output
       --metrics-interval duration   defines the interval of metrics output to log (default 5m0s)
+      --skip-bootstrap              enable skipping checkpoint register payloads indexing
   -t, --trie string                 data directory for state ledger
 ```
 

--- a/cmd/flow-dps-indexer/main.go
+++ b/cmd/flow-dps-indexer/main.go
@@ -89,7 +89,7 @@ func run() int {
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 	pflag.BoolVarP(&flagMetrics, "metrics", "m", false, "enable metrics collection and output")
 	pflag.DurationVar(&flagMetricsInterval, "metrics-interval", 5*time.Minute, "defines the interval of metrics output to log")
-	pflag.BoolVar(&flagSkipBootstrap, "skip-bootstrap", false, "enable skipping the checkpoint registers")
+	pflag.BoolVar(&flagSkipBootstrap, "skip-bootstrap", false, "enable skipping checkpoint register payloads indexing")
 	pflag.StringVarP(&flagTrie, "trie", "t", "", "data directory for state ledger")
 
 	pflag.Parse()

--- a/cmd/flow-dps-indexer/main.go
+++ b/cmd/flow-dps-indexer/main.go
@@ -71,6 +71,7 @@ func run() int {
 		flagLevel             string
 		flagMetrics           bool
 		flagMetricsInterval   time.Duration
+		flagSkipBootstrap     bool
 		flagTrie              string
 	)
 
@@ -88,6 +89,7 @@ func run() int {
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 	pflag.BoolVarP(&flagMetrics, "metrics", "m", false, "enable metrics collection and output")
 	pflag.DurationVar(&flagMetricsInterval, "metrics-interval", 5*time.Minute, "defines the interval of metrics output to log")
+	pflag.BoolVar(&flagSkipBootstrap, "skip-bootstrap", false, "enable skipping the checkpoint registers")
 	pflag.StringVarP(&flagTrie, "trie", "t", "", "data directory for state ledger")
 
 	pflag.Parse()
@@ -210,6 +212,7 @@ func run() int {
 		mapper.WithIndexTransactions(flagIndexAll || flagIndexTransactions),
 		mapper.WithIndexEvents(flagIndexAll || flagIndexEvents),
 		mapper.WithIndexPayloads(flagIndexAll || flagIndexPayloads),
+		mapper.WithSkipBootstrap(flagSkipBootstrap),
 	)
 	forest := forest.New()
 	state := mapper.EmptyState(forest)

--- a/service/mapper/config.go
+++ b/service/mapper/config.go
@@ -22,6 +22,7 @@ var DefaultConfig = Config{
 	IndexTransactions: false,
 	IndexEvents:       false,
 	IndexPayloads:     false,
+	SkipBootstrap:     false,
 }
 
 // Config contains optional parameters for the mapper.
@@ -32,6 +33,7 @@ type Config struct {
 	IndexTransactions bool
 	IndexEvents       bool
 	IndexPayloads     bool
+	SkipBootstrap     bool
 }
 
 // WithIndexCommit sets up the mapper to build the commits index.
@@ -73,5 +75,13 @@ func WithIndexEvents(b bool) func(*Config) {
 func WithIndexPayloads(b bool) func(*Config) {
 	return func(cfg *Config) {
 		cfg.IndexPayloads = b
+	}
+}
+
+// WithSkipBootstrap sets the mapper up to skip indexing the registers from the
+// initial checkpoint.
+func WithSkipBootstrap(b bool) func(*Config) {
+	return func(cfg *Config) {
+		cfg.SkipBootstrap = b
 	}
 }

--- a/service/mapper/transitions.go
+++ b/service/mapper/transitions.go
@@ -98,7 +98,10 @@ func (t *Transitions) BootstrapState(s *State) error {
 	}
 
 	// Here, we store all the paths so we can index the payloads, if wanted.
-	paths := allPaths(checkpoint)
+	var paths []ledger.Path
+	if !t.cfg.SkipBootstrap {
+		paths = allPaths(checkpoint)
+	}
 	s.forest.Save(checkpoint, paths, first)
 
 	second := checkpoint.RootHash()


### PR DESCRIPTION
## Goal of this PR

This PR addresses an issue I encountered when trying to get metrics for storage. If we run the indexer in a normal way, it will take several hours to index the payloads for the checkpoint registers. During that time, not only do we not get metrics on other entities; the timing metrics will be warped because they will be strongly biased towards payloads.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] ~~Tests are up-to-date~~