### PR TITLE
Indexer: increase GOMAXPROCS variable

### DIFF
--- a/cmd/flow-dps-indexer/main.go
+++ b/cmd/flow-dps-indexer/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"runtime"
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
@@ -90,6 +91,10 @@ func run() int {
 	pflag.StringVarP(&flagTrie, "trie", "t", "", "data directory for state ledger")
 
 	pflag.Parse()
+
+	// Increase the GOMAXPROCS value in order to use the full IOPS available, see:
+	// https://groups.google.com/g/golang-nuts/c/jPb_h3TvlKE
+	_ = runtime.GOMAXPROCS(128)
 
 	// Logger initialization.
 	zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }


### PR DESCRIPTION
## Goal of this PR

While investigating ways to improve Badger performance, I came across an interesting entry in their FAQ, that pointed me to a Go mailing list discussion (found in the code comment of the PR).

In summary, when talking about disk I/O, the interaction between the Go runtime and the OS scheduler creates a situation where Go routines can be starved off having an OS thread to run on, even when some CPU cores are idle. So the default value of `GOMAXPROCS` is too low for disk I/O intensive applications.

Dgraph themselves, which is built on Badger, uses a value of 128, so I have just used the same here.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] ~~Tests are up-to-date~~