### PR TITLE
Indexer: optimize badger write performance.

### DIFF
--- a/cmd/flow-dps-indexer/main.go
+++ b/cmd/flow-dps-indexer/main.go
@@ -197,6 +197,12 @@ func run() int {
 
 	// Writer is responsible for writing the index data to the index database.
 	index := index.NewWriter(db, storage)
+	defer func() {
+		err := index.Close()
+		if err != nil {
+			log.Error().Err(err).Msg("could not close index")
+		}
+	}()
 	write := dps.Writer(index)
 	if flagMetrics {
 		time := rcrowley.NewTime("write")
@@ -280,13 +286,6 @@ func run() int {
 	if err != nil {
 		log.Error().Err(err).Msg("could not stop indexer")
 		return failure
-	}
-
-	// Last but not least, we should flush the writer to commit any pending
-	// transactions to the database.
-	err = index.Close()
-	if err != nil {
-		log.Error().Err(err).Msg("could not close index")
 	}
 
 	return success

--- a/cmd/flow-dps-indexer/main.go
+++ b/cmd/flow-dps-indexer/main.go
@@ -196,8 +196,8 @@ func run() int {
 	}
 
 	// Writer is responsible for writing the index data to the index database.
-	var write dps.Writer
-	write = index.NewWriter(db, storage)
+	index := index.NewWriter(db, storage)
+	write := dps.Writer(index)
 	if flagMetrics {
 		time := rcrowley.NewTime("write")
 		mout.Register(time)
@@ -280,6 +280,13 @@ func run() int {
 	if err != nil {
 		log.Error().Err(err).Msg("could not stop indexer")
 		return failure
+	}
+
+	// Last but not least, we should flush the writer to commit any pending
+	// transactions to the database.
+	err = index.Close()
+	if err != nil {
+		log.Error().Err(err).Msg("could not close index")
 	}
 
 	return success

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/ziflex/lecho/v2 v2.3.1
 	golang.org/x/mod v0.3.0
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	google.golang.org/grpc v1.37.1
 	google.golang.org/protobuf v1.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1100,6 +1100,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/service/index/config.go
+++ b/service/index/config.go
@@ -1,0 +1,29 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package index
+
+var DefaultConfig = Config{
+	ConcurrentTransactions: 16, // same value as used for batches in badger
+}
+
+type Config struct {
+	ConcurrentTransactions uint
+}
+
+func WithConcurrentTransactions(concurrent uint) func(*Config) {
+	return func(cfg *Config) {
+		cfg.ConcurrentTransactions = concurrent
+	}
+}

--- a/service/index/writer.go
+++ b/service/index/writer.go
@@ -15,29 +15,48 @@
 package index
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/dgraph-io/badger/v2"
-	"github.com/optakt/flow-dps/models/dps"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
+
+	"github.com/optakt/flow-dps/models/dps"
 )
 
 // Writer implements the `index.Writer` interface to write indexing data to
 // an underlying Badger database.
 type Writer struct {
-	db  *badger.DB
-	lib dps.WriteLibrary
+	sync.RWMutex
+	db   *badger.DB
+	lib  dps.WriteLibrary
+	cfg  Config
+	tx   *badger.Txn
+	sema *semaphore.Weighted
+	err  error
 }
 
 // NewWriter creates a new index writer that writes new indexing data to the
 // given Badger database.
-func NewWriter(db *badger.DB, lib dps.WriteLibrary) *Writer {
+func NewWriter(db *badger.DB, lib dps.WriteLibrary, options ...func(*Config)) *Writer {
+
+	cfg := DefaultConfig
+	for _, option := range options {
+		option(&cfg)
+	}
 
 	w := Writer{
-		db:  db,
-		lib: lib,
+		db:   db,
+		lib:  lib,
+		cfg:  cfg,
+		tx:   db.NewTransaction(true),
+		sema: semaphore.NewWeighted(int64(cfg.ConcurrentTransactions)),
+		err:  nil,
 	}
 
 	return &w
@@ -45,28 +64,28 @@ func NewWriter(db *badger.DB, lib dps.WriteLibrary) *Writer {
 
 // First indexes the height of the first finalized block.
 func (w *Writer) First(height uint64) error {
-	return w.db.Update(w.lib.SaveFirst(height))
+	return w.apply(w.lib.SaveFirst(height))
 }
 
 // Last indexes the height of the last finalized block.
 func (w *Writer) Last(height uint64) error {
-	return w.db.Update(w.lib.SaveLast(height))
+	return w.apply(w.lib.SaveLast(height))
 }
 
 // Height indexes the height for the given block ID.
 func (w *Writer) Height(blockID flow.Identifier, height uint64) error {
-	return w.db.Update(w.lib.IndexHeightForBlock(blockID, height))
+	return w.apply(w.lib.IndexHeightForBlock(blockID, height))
 }
 
 // Commit indexes the given commitment of the execution state as it was after
 // the execution of the finalized block at the given height.
 func (w *Writer) Commit(height uint64, commit flow.StateCommitment) error {
-	return w.db.Update(w.lib.SaveCommit(height, commit))
+	return w.apply(w.lib.SaveCommit(height, commit))
 }
 
 // Header indexes the given header of a finalized block at the given height.
 func (w *Writer) Header(height uint64, header *flow.Header) error {
-	return w.db.Update(w.lib.SaveHeader(height, header))
+	return w.apply(w.lib.SaveHeader(height, header))
 }
 
 // Payloads indexes the given payloads, which should represent a trie update
@@ -76,7 +95,7 @@ func (w *Writer) Payloads(height uint64, paths []ledger.Path, payloads []*ledger
 	if len(paths) != len(payloads) {
 		return fmt.Errorf("mismatch between paths and payloads counts")
 	}
-	return w.db.Update(func(tx *badger.Txn) error {
+	return w.apply(func(tx *badger.Txn) error {
 		for i, path := range paths {
 			payload := payloads[i]
 			err := w.lib.SavePayload(height, path, payload)(tx)
@@ -90,7 +109,7 @@ func (w *Writer) Payloads(height uint64, paths []ledger.Path, payloads []*ledger
 
 func (w *Writer) Collections(height uint64, collections []*flow.LightCollection) error {
 	var collIDs []flow.Identifier
-	return w.db.Update(func(tx *badger.Txn) error {
+	return w.apply(func(tx *badger.Txn) error {
 		for _, collection := range collections {
 			err := w.lib.SaveCollection(collection)(tx)
 			if err != nil {
@@ -113,15 +132,15 @@ func (w *Writer) Collections(height uint64, collections []*flow.LightCollection)
 
 func (w *Writer) Transactions(height uint64, transactions []*flow.TransactionBody) error {
 	var txIDs []flow.Identifier
-	return w.db.Update(func(tx *badger.Txn) error {
+	return w.apply(func(tx *badger.Txn) error {
 		for _, transaction := range transactions {
-			err := w.db.Update(w.lib.SaveTransaction(transaction))
+			err := w.lib.SaveTransaction(transaction)(tx)
 			if err != nil {
 				return fmt.Errorf("could not save transaction (id: %x): %w", transaction.ID(), err)
 			}
 			txIDs = append(txIDs, transaction.ID())
 		}
-		err := w.db.Update(w.lib.IndexTransactionsForHeight(height, txIDs))
+		err := w.lib.IndexTransactionsForHeight(height, txIDs)(tx)
 		if err != nil {
 			return fmt.Errorf("could not index transactions for height: %w", err)
 		}
@@ -136,7 +155,7 @@ func (w *Writer) Events(height uint64, events []flow.Event) error {
 	for _, event := range events {
 		buckets[event.Type] = append(buckets[event.Type], event)
 	}
-	err := w.db.Update(func(tx *badger.Txn) error {
+	err := w.apply(func(tx *badger.Txn) error {
 		for typ, evts := range buckets {
 			err := w.lib.SaveEvents(height, typ, evts)(tx)
 			if err != nil {
@@ -147,6 +166,43 @@ func (w *Writer) Events(height uint64, events []flow.Event) error {
 	})
 	if err != nil {
 		return fmt.Errorf("could not index events: %w", err)
+	}
+	return nil
+}
+
+func (w *Writer) apply(op func(*badger.Txn) error) error {
+	w.RLock()
+	err := w.err
+	w.RUnlock()
+	if err != nil {
+		return fmt.Errorf("could not commit transaction: %w", w.err)
+	}
+	err = op(w.tx)
+	if errors.Is(err, badger.ErrTxnTooBig) {
+		w.tx.CommitWith(w.done)
+		_ = w.sema.Acquire(context.Background(), 1)
+		w.tx = w.db.NewTransaction(true)
+		err = op(w.tx)
+	}
+	if err != nil {
+		return fmt.Errorf("could not apply operation: %w", err)
+	}
+	return nil
+}
+
+func (w *Writer) done(err error) {
+	if err != nil {
+		w.Lock()
+		w.err = err
+		w.Unlock()
+	}
+	w.sema.Release(1)
+}
+
+func (w *Writer) Close() error {
+	_ = w.sema.Acquire(context.Background(), int64(w.cfg.ConcurrentTransactions))
+	if w.err != nil {
+		return fmt.Errorf("could not flush transactions: %w", w.err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Goal of this PR

This PR takes inspiration from the batching API of Badger, without actually breaking our own neat design, in order to optimize write performance. Essentially, it comes down to two points:

- make transactions as big as possible; and
- build new transactions while old ones are committing.

This maximizes the throughput; sometimes you can notice a slowdown in block processing, which is probably when it reaches the maximum number of concurrent transactions. Overall, though, performance seems to have increased 30-40x.

Fixes #272.

Fixes #273.

## Checklist

- [x] Is on the right branch
- [x] ~~Documentation is up-to-date~~
- [x] Tests are up-to-date