### PR TITLE
Add go mod cache to CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           go-version: 1.16
 
+      - name: Cache Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       # Here, we simply print the exact go version, to have it as part of the
       # action's output, which might be convenient.
       - name: Print Go version


### PR DESCRIPTION
## Goal of this PR

Just small CI improvement to keep our builds fast in the future.

## Checklist

- [x] Is on the right branch
- [ ] ~Documentation is up-to-date~
- [ ] ~Tests are up-to-date~