### PR TITLE
Adding back height indexing

### DIFF
--- a/service/mapper/transitions.go
+++ b/service/mapper/transitions.go
@@ -350,6 +350,10 @@ func (t *Transitions) IndexChain(s *State) error {
 			return fmt.Errorf("could not index header: %w", err)
 		}
 		blockID := header.ID()
+		err = t.index.Height(blockID, s.height)
+		if err != nil {
+			return fmt.Errorf("could not index height: %w", err)
+		}
 		log = log.Hex("block", blockID[:])
 	}
 	if t.cfg.IndexCollections {

--- a/service/mapper/transitions_test.go
+++ b/service/mapper/transitions_test.go
@@ -521,7 +521,7 @@ func TestTransitions_IndexChain(t *testing.T) {
 		}
 		index.HeightFunc = func(blockID flow.Identifier, height uint64) error {
 			assert.Equal(t, mocks.GenericHeight, height)
-			assert.Equal(t, mocks.GenericIdentifier(0), blockID)
+			assert.Equal(t, mocks.GenericHeader.ID(), blockID)
 
 			return nil
 		}


### PR DESCRIPTION
## Goal of this PR

Fixes #281 

This PR re-adds indexing of heights to the indexer.

In the mapper code, I cached the block identifier if indexing headers was enabled. That way we don't need to retrieve the block header twice in order to index header and height.

I was also thinking this might be the default option if `index-headers` was selected, dunno..

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date