### PR TITLE
Add GoReleaser config and GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,18 +4,13 @@ name: CI
 # is created or updated.
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
-# A workflow is made up of one or more jobs, which can be run in sequence or in
-# parallel. In this case, we have a single job, called "check", that runs on
-# the latest Ubuntu image.
 jobs:
   check:
     runs-on: ubuntu-latest
 
-    # A job is made up of sequential steps. The pre-defined checkout step checks
-    # out the source code to $GITHUB_WORKSPACE, while the pre-defined setup-go
-    # step installs the Go at the configured version.
     steps:
       - name: Check out source code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: AutoRelease
+
+# AutoRelease will run whenever a tag is pushed.
+on:
+  pull_request:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      # Install GoReleaser and print its version before running.
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          install-only: true
+
+      - name: Show GoReleaser version
+        run: goreleaser -v
+
+      # Run GoReleaser.
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: AutoRelease
 
 # AutoRelease will run whenever a tag is pushed.
 on:
-  pull_request:
+  push:
     tags:
       - '*'
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.cdc
 *.log
 *.checkpoint
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,57 @@
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+# By default, builds only for darwin and linux, which works for us since FlowGo does not support
+# Windows builds. We also can only build on amd64 architectures since all others are also not
+# supported at the moment.
+builds:
+  - id: dps-client
+    binary: dps-client
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+    main: ./cmd/flow-dps-client
+
+  - id: dps-indexer
+    binary: dps-indexer
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+    main: ./cmd/flow-dps-indexer
+
+  - id: dps-server
+    binary: dps-server
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+    main: ./cmd/flow-dps-server
+
+  - id: rosetta-server
+    binary: rosetta-server
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+    main: ./cmd/flow-rosetta-server
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
## Goal of this PR

Fixes #255 

If I understood correctly how this works, it should also automatically add the binaries to the release for us as well as the checksum of those binaries (in a `checksum.txt` file.)

Unfortunately I can't really test that part until we do create and push a tag, so for now let's already see if this looks good to everyone and we'll figure the rest out later 🤷 

## Additional Notes

@awfm9 This script needs for a GitHub token with repo rights to be added to the repo's secrets in the admin setting, otherwise it won't be able to publish the release. It can be a good idea though to not set it for now, and when we do our first release, run it once first expecting it to fail on publish, for us to double check that everything makes sense before we let it publish anything.

Worst case scenario though, releases are reversible so there's not much harm done if it fucks up, just a small waste of time.

Also, I'm not 100% sure if we need to enable the GoReleaser GH Action from the Marketplace or if importing it directly from the script is ok. If it fails directly when we try to release that might be why.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date