### PR TITLE
Rosetta: add missing empty response fields

### DIFF
--- a/api/rosetta/options.go
+++ b/api/rosetta/options.go
@@ -43,6 +43,9 @@ type Allow struct {
 	OperationTypes          []string                `json:"operation_types"`
 	Errors                  []meta.ErrorDefinition  `json:"errors"`
 	HistoricalBalanceLookup bool                    `json:"historical_balance_lookup"`
+	CallMethods             []string                `json:"call_methods"`       // not used
+	BalanceExemptions       []interface{}           `json:"balance_exemptions"` // not used
+	MempoolCoins            bool                    `json:"mempool_coins"`
 }
 
 // Options implements the /network/options endpoint of the Rosetta Data API.
@@ -78,6 +81,9 @@ func (d *Data) Options(ctx echo.Context) error {
 		OperationTypes:          d.config.Operations(),
 		Errors:                  d.config.Errors(),
 		HistoricalBalanceLookup: true,
+		CallMethods:             []string{},
+		BalanceExemptions:       []interface{}{},
+		MempoolCoins:            false,
 	}
 
 	res := OptionsResponse{

--- a/api/rosetta/options.go
+++ b/api/rosetta/options.go
@@ -44,7 +44,7 @@ type Allow struct {
 	Errors                  []meta.ErrorDefinition  `json:"errors"`
 	HistoricalBalanceLookup bool                    `json:"historical_balance_lookup"`
 	CallMethods             []string                `json:"call_methods"`       // not used
-	BalanceExemptions       []interface{}           `json:"balance_exemptions"` // not used
+	BalanceExemptions       []struct{}              `json:"balance_exemptions"` // not used
 	MempoolCoins            bool                    `json:"mempool_coins"`
 }
 
@@ -82,7 +82,7 @@ func (d *Data) Options(ctx echo.Context) error {
 		Errors:                  d.config.Errors(),
 		HistoricalBalanceLookup: true,
 		CallMethods:             []string{},
-		BalanceExemptions:       []interface{}{},
+		BalanceExemptions:       []struct{}{},
 		MempoolCoins:            false,
 	}
 

--- a/api/rosetta/status.go
+++ b/api/rosetta/status.go
@@ -37,6 +37,7 @@ type StatusResponse struct {
 	CurrentBlockTimestamp int64            `json:"current_block_timestamp"`
 	OldestBlockID         identifier.Block `json:"oldest_block_identifier"`
 	GenesisBlockID        identifier.Block `json:"genesis_block_identifier"`
+	Peers                 []struct{}       `json:"peers"` // not used
 }
 
 // Status implements the /network/status endpoint of the Rosetta Data API.
@@ -79,6 +80,7 @@ func (d *Data) Status(ctx echo.Context) error {
 		CurrentBlockTimestamp: timestamp.UnixNano() / 1_000_000,
 		OldestBlockID:         oldest,
 		GenesisBlockID:        oldest,
+		Peers:                 []struct{}{},
 	}
 
 	return ctx.JSON(http.StatusOK, res)


### PR DESCRIPTION
## Goal of this PR

Fixes #310.

The Rosetta documentation specifies a lot of fields as required, even though we discussed with the Coinbase team that they should be empty. Essentially, they should then contain empty lists or an explicit `nil` value. This PR fixes these discrepancies.

## Checklist

- [x] Is on the right branch
- [ ] ~Documentation is up-to-date~
- [ ] ~Tests are up-to-date~