### PR TITLE
Fixing transaction ID slicing for transaction listing

### DIFF
--- a/api/dps/server.go
+++ b/api/dps/server.go
@@ -214,7 +214,8 @@ func (s *Server) ListTransactionsForHeight(_ context.Context, req *ListTransacti
 
 	transactionIDs := make([][]byte, 0, len(txIDs))
 	for _, txID := range txIDs {
-		transactionIDs = append(transactionIDs, txID[:])
+		id := txID
+		transactionIDs = append(transactionIDs, id[:])
 	}
 
 	res := ListTransactionsForHeightResponse{

--- a/api/dps/server.go
+++ b/api/dps/server.go
@@ -214,8 +214,8 @@ func (s *Server) ListTransactionsForHeight(_ context.Context, req *ListTransacti
 
 	transactionIDs := make([][]byte, 0, len(txIDs))
 	for _, txID := range txIDs {
-		id := txID
-		transactionIDs = append(transactionIDs, id[:])
+		txID := txID
+		transactionIDs = append(transactionIDs, txID[:])
 	}
 
 	res := ListTransactionsForHeightResponse{


### PR DESCRIPTION
## Goal of this PR

This PR fixes listing transactions for a block height. Because a loop variable memory is probably reused, we end up slicing the same underlying storage, and the end result turns out to be the same ID listed n times.

Example output for mainnet9:
```
listing transactions for block 14951074
#0 - b839c2d5f2a47175d519bdc6b1606cedb954ac4f1b7d68ed5ed63d41fc670e78
#1 - b839c2d5f2a47175d519bdc6b1606cedb954ac4f1b7d68ed5ed63d41fc670e78
#2 - b839c2d5f2a47175d519bdc6b1606cedb954ac4f1b7d68ed5ed63d41fc670e78
#3 - b839c2d5f2a47175d519bdc6b1606cedb954ac4f1b7d68ed5ed63d41fc670e78
#4 - b839c2d5f2a47175d519bdc6b1606cedb954ac4f1b7d68ed5ed63d41fc670e78
#5 - b839c2d5f2a47175d519bdc6b1606cedb954ac4f1b7d68ed5ed63d41fc670e78
#6 - b839c2d5f2a47175d519bdc6b1606cedb954ac4f1b7d68ed5ed63d41fc670e78
listing transactions for block 14951075
#0 - 433865ad2692c00ba1c9c838880e8a221bc940867afedb2001eeb49ed4b97785
listing transactions for block 14951076
#0 - 5c5c4ced2632811065bfa3776f0cd1295432d0924b24b4ad645195a3f0c1b106
#1 - 5c5c4ced2632811065bfa3776f0cd1295432d0924b24b4ad645195a3f0c1b106
```


## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date