### PR TITLE
Add support for block hash only identifiers

### DIFF
--- a/api/rosetta/errors.go
+++ b/api/rosetta/errors.go
@@ -141,8 +141,6 @@ func invalidBlock(fail failure.InvalidBlock) Error {
 	return convertError(
 		configuration.ErrorInvalidBlock,
 		fail.Description,
-		withDetail("index", fail.Index),
-		withDetail("hash", fail.Hash),
 	)
 }
 

--- a/rosetta/failure/invalid_block.go
+++ b/rosetta/failure/invalid_block.go
@@ -20,10 +20,8 @@ import (
 
 type InvalidBlock struct {
 	Description Description
-	Index       uint64
-	Hash        string
 }
 
 func (i InvalidBlock) Error() string {
-	return fmt.Sprintf("invalid block (index: %d, hash: %s): %s", i.Index, i.Hash, i.Description)
+	return fmt.Sprintf("invalid block: %s", i.Description)
 }

--- a/rosetta/validator/block.go
+++ b/rosetta/validator/block.go
@@ -71,7 +71,6 @@ func (v *Validator) Block(rosBlockID identifier.Block) (identifier.Block, error)
 				Index: *rosBlockID.Index,
 				Hash:  rosBlockID.Hash,
 				Description: failure.NewDescription("block index is above last indexed height",
-					failure.WithUint64("block_index", *rosBlockID.Index),
 					failure.WithUint64("last_index", last),
 				),
 			}

--- a/rosetta/validator/block.go
+++ b/rosetta/validator/block.go
@@ -29,10 +29,11 @@ import (
 // valid, so we will have at least a height or a hash.
 func (v *Validator) Block(rosBlockID identifier.Block) (identifier.Block, error) {
 
-	// We currently only support retrieval by height, until we start indexing
-	// the block IDs as part of the DPS index.
-	if rosBlockID.Index == nil {
-		return identifier.Block{}, fmt.Errorf("block retrieval by hash only is currently not supported")
+	// If both the index and the hash are missing, the block identifier is invalid.
+	if rosBlockID.Index == nil && rosBlockID.Hash == "" {
+		return identifier.Block{}, failure.InvalidBlock{
+			Description: failure.NewDescription("block needs either a valid index or a valid hash"),
+		}
 	}
 
 	// If a block hash is present, it should be a valid block ID for Flow.
@@ -40,41 +41,51 @@ func (v *Validator) Block(rosBlockID identifier.Block) (identifier.Block, error)
 		_, err := flow.HexStringToIdentifier(rosBlockID.Hash)
 		if err != nil {
 			return identifier.Block{}, failure.InvalidBlock{
-				Index:       *rosBlockID.Index,
-				Hash:        rosBlockID.Hash,
-				Description: failure.NewDescription("block hash is not a valid hex-encoded string"),
+				Description: failure.NewDescription("block hash is not a valid hex-encoded string",
+					failure.WithString("block_hash", rosBlockID.Hash),
+				),
 			}
 		}
 	}
 
-	// The block index can't be below the first indexed height.
-	first, err := v.index.First()
-	if err != nil {
-		return identifier.Block{}, fmt.Errorf("could not get first: %w", err)
-	}
-	if *rosBlockID.Index < first {
-		return identifier.Block{}, failure.InvalidBlock{
-			Index: *rosBlockID.Index,
-			Hash:  rosBlockID.Hash,
-			Description: failure.NewDescription("block index is below first indexed height",
-				failure.WithUint64("first_index", first),
-			),
+	// If a block index is present, it should be a valid height for the DPS.
+	if rosBlockID.Index != nil {
+		first, err := v.index.First()
+		if err != nil {
+			return identifier.Block{}, fmt.Errorf("could not get first: %w", err)
+		}
+		if *rosBlockID.Index < first {
+			return identifier.Block{}, failure.InvalidBlock{
+				Description: failure.NewDescription("block index is below first indexed height",
+					failure.WithUint64("block_index", *rosBlockID.Index),
+					failure.WithUint64("first_index", first),
+				),
+			}
+		}
+		last, err := v.index.Last()
+		if err != nil {
+			return identifier.Block{}, fmt.Errorf("could not get last: %w", err)
+		}
+		if *rosBlockID.Index > last {
+			return identifier.Block{}, failure.UnknownBlock{
+				Index: *rosBlockID.Index,
+				Hash:  rosBlockID.Hash,
+				Description: failure.NewDescription("block index is above last indexed height",
+					failure.WithUint64("block_index", *rosBlockID.Index),
+					failure.WithUint64("last_index", last),
+				),
+			}
 		}
 	}
 
-	// The block index can't be above the last indexed height.
-	last, err := v.index.Last()
-	if err != nil {
-		return identifier.Block{}, fmt.Errorf("could not get last: %w", err)
-	}
-	if *rosBlockID.Index > last {
-		return identifier.Block{}, failure.UnknownBlock{
-			Index: *rosBlockID.Index,
-			Hash:  rosBlockID.Hash,
-			Description: failure.NewDescription("block index is above last indexed height",
-				failure.WithUint64("last_index", last),
-			),
+	// If we don't have a height, fill it in now.
+	if rosBlockID.Index == nil {
+		blockID, _ := flow.HexStringToIdentifier(rosBlockID.Hash)
+		height, err := v.index.HeightForBlock(blockID)
+		if err != nil {
+			return identifier.Block{}, fmt.Errorf("could not get height for block: %w", err)
 		}
+		rosBlockID.Index = &height
 	}
 
 	// The given block ID should match the block ID at the given height.
@@ -84,9 +95,9 @@ func (v *Validator) Block(rosBlockID identifier.Block) (identifier.Block, error)
 	}
 	if rosBlockID.Hash != "" && rosBlockID.Hash != header.ID().String() {
 		return identifier.Block{}, failure.InvalidBlock{
-			Index: *rosBlockID.Index,
-			Hash:  rosBlockID.Hash,
 			Description: failure.NewDescription("block hash mismatches with authoritative hash for index",
+				failure.WithUint64("block_index", *rosBlockID.Index),
+				failure.WithString("block_hash", rosBlockID.Hash),
 				failure.WithString("want_hash", header.ID().String()),
 			),
 		}


### PR DESCRIPTION
## Goal of this PR

Now that we have a block hash to height index, we should use it in Rosetta to support block identifiers that only have a hash and no index.

## Checklist

- [x] Is on the right branch
- [ ] ~Documentation is up-to-date~
- [ ] ~Tests are up-to-date~