### PR TITLE
Construction API base code and Preprocess endpoint

### DIFF
--- a/api/rosetta/client.go
+++ b/api/rosetta/client.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package rosetta
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/onflow/flow-go-sdk"
+)
+
+type Client interface {
+	SendTransaction(ctx context.Context, tx flow.Transaction, options ...grpc.CallOption) error
+}

--- a/api/rosetta/construction.go
+++ b/api/rosetta/construction.go
@@ -34,22 +34,21 @@ const (
 // Construction implements the Rosetta Construction API specification.
 // See https://www.rosetta-api.org/docs/construction_api_introduction.html
 type Construction struct {
-	config    Configuration
-	parser    Parser
+	config Configuration
+	parser Parser
+
+	// Retriever is used to retrieve the latest block ID. This is needed
+	// since the transactions require a reference block ID, so that
+	// their validity or expiration can be determined.
 	retriever Retriever
-	client    Client
+
+	// Client is used to submit the constructed transaction to the Flow network.
+	client Client
 }
 
 // NewConstruction creates a new instance of the Construction API using the given configuration
 // to handle transaction construction requests.
 func NewConstruction(config Configuration, parser Parser, retriever Retriever, client Client) *Construction {
-
-	// The retriever has a number of capabilities, but in the context of the
-	// Rosetta Construction API, it is only used to retrieve the latest block ID.
-	// This is needed since the transactions require a reference block ID, so that
-	// their validity or expiration can be determined.
-
-	// Client is used to submit the constructed transaction to the Flow network.
 
 	c := Construction{
 		config:    config,

--- a/api/rosetta/construction.go
+++ b/api/rosetta/construction.go
@@ -15,7 +15,7 @@
 package rosetta
 
 const (
-	// FlowSignatureAlgorithm denotes the signing algorithm supported by Flow.
+	// FlowSignatureAlgorithm is the signing algorithm supported by Flow.
 	FlowSignatureAlgorithm = "ecdsa"
 )
 

--- a/api/rosetta/construction.go
+++ b/api/rosetta/construction.go
@@ -19,17 +19,16 @@ const (
 	FlowSignatureAlgorithm = "ecdsa"
 )
 
-// TODO: We could consider moving Data and Construction APIs to separate packages.
-// TODO: when the construction API crystalizes, make all the error returns consistent
-// TODO: as a WIP thing - treat the sender as the proposer and the payer. Consider allowing more granular control.
-// TODO: set gas limit for the transaction.
-// TODO: get account sequence number for the metadata endpoint
-//
-// TODO: check - We are serialiing/deserializing the transactions a few times. Originally
-// I created a TransactionPayload structure that is identical to flow.Transaction, except
-// it had JSON tags so the outputted JSON was nicer. However, since it led to overhead
-// and the need to convert the structures back and forth, I opted for removing it and always
-// using flow.Transaction, even if the resulting JSON reads like `{ "Script": "..." }` (uppercased field name).
+// TODO: Separate Data and Construction APIs to separate packages.
+// => https://github.com/optakt/flow-dps/issues/330
+
+// TODO: Sender is also the proposer and the payer. Consider allowing more granular control.
+// => https://github.com/optakt/flow-dps/issues/331
+
+// TODO: Specify Gas limit for the transaction.
+// => https://github.com/optakt/flow-dps/issues/332
+
+// FIXME: get account sequence number for the metadata endpoint (uses Access API)
 
 // Construction implements the Rosetta Construction API specification.
 // See https://www.rosetta-api.org/docs/construction_api_introduction.html

--- a/api/rosetta/construction.go
+++ b/api/rosetta/construction.go
@@ -1,0 +1,62 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package rosetta
+
+const (
+	// FlowSignatureAlgorithm denotes the signing algorithm supported by Flow.
+	FlowSignatureAlgorithm = "ecdsa"
+)
+
+// TODO: We could consider moving Data and Construction APIs to separate packages.
+// TODO: when the construction API crystalizes, make all the error returns consistent
+// TODO: as a WIP thing - treat the sender as the proposer and the payer. Consider allowing more granular control.
+// TODO: set gas limit for the transaction.
+// TODO: get account sequence number for the metadata endpoint
+//
+// TODO: check - We are serialiing/deserializing the transactions a few times. Originally
+// I created a TransactionPayload structure that is identical to flow.Transaction, except
+// it had JSON tags so the outputted JSON was nicer. However, since it led to overhead
+// and the need to convert the structures back and forth, I opted for removing it and always
+// using flow.Transaction, even if the resulting JSON reads like `{ "Script": "..." }` (uppercased field name).
+
+// Construction implements the Rosetta Construction API specification.
+// See https://www.rosetta-api.org/docs/construction_api_introduction.html
+type Construction struct {
+	config    Configuration
+	parser    Parser
+	retriever Retriever
+	client    Client
+}
+
+// NewConstruction creates a new instance of the Construction API using the given configuration
+// to handle transaction construction requests.
+func NewConstruction(config Configuration, parser Parser, retriever Retriever, client Client) *Construction {
+
+	// The retriever has a number of capabilities, but in the context of the
+	// Rosetta Construction API, it is only used to retrieve the latest block ID.
+	// This is needed since the transactions require a reference block ID, so that
+	// their validity or expiration can be determined.
+
+	// Client is used to submit the constructed transaction to the Flow network.
+
+	c := Construction{
+		config:    config,
+		parser:    parser,
+		retriever: retriever,
+		client:    client,
+	}
+
+	return &c
+}

--- a/api/rosetta/errors.go
+++ b/api/rosetta/errors.go
@@ -23,16 +23,17 @@ import (
 const (
 	invalidJSON = "request does not contain valid JSON-encoded body"
 
-	blockchainEmpty = "blockchain identifier has empty blockchain field"
-	networkEmpty    = "blockchain identifier has empty network field"
-	blockEmpty      = "block identifier has empty index and hash fields"
-	blockLength     = "block identifier has invalid hash field length"
-	addressEmpty    = "account identifier has empty address field"
-	addressLength   = "account identifier has invalid address field length"
-	currenciesEmpty = "currency identifier list is empty"
-	symbolEmpty     = "currency identifier has empty symbol field"
-	txEmpty         = "transaction identifier has empty hash field"
-	txLength        = "transaction identifier has invalid hash filed length"
+	blockchainEmpty  = "blockchain identifier has empty blockchain field"
+	networkEmpty     = "blockchain identifier has empty network field"
+	blockEmpty       = "block identifier has empty index and hash fields"
+	blockLength      = "block identifier has invalid hash field length"
+	addressEmpty     = "account identifier has empty address field"
+	addressLength    = "account identifier has invalid address field length"
+	currenciesEmpty  = "currency identifier list is empty"
+	symbolEmpty      = "currency identifier has empty symbol field"
+	txEmpty          = "transaction identifier has empty hash field"
+	txLength         = "transaction identifier has invalid hash filed length"
+	txInvalidOpCount = "transaction operations list has an invalid number of operations"
 
 	networkCheck      = "unable to check network"
 	blockRetrieval    = "unable to retrieve block"
@@ -40,6 +41,7 @@ const (
 	oldestRetrieval   = "unable to retrieve oldest block"
 	currentRetrieval  = "unable to retrieve current block"
 	txRetrieval       = "unable to retrieve transaction"
+	intentCreate      = "unable to determine transaction intent"
 )
 
 // Error represents an error as defined by the Rosetta API specification. It
@@ -175,5 +177,14 @@ func unknownTransaction(fail failure.UnknownTransaction) Error {
 		configuration.ErrorUnknownTransaction,
 		fail.Description,
 		withDetail("hash", fail.Hash),
+	)
+}
+
+func invalidIntent(fail failure.InvalidIntent) Error {
+	return convertError(
+		configuration.ErrorInvalidTransactionIntent,
+		fail.Description,
+		withDetail("from", fail.Sender),
+		withDetail("to", fail.Receiver),
 	)
 }

--- a/api/rosetta/errors.go
+++ b/api/rosetta/errors.go
@@ -41,7 +41,7 @@ const (
 	oldestRetrieval   = "unable to retrieve oldest block"
 	currentRetrieval  = "unable to retrieve current block"
 	txRetrieval       = "unable to retrieve transaction"
-	intentCreate      = "unable to determine transaction intent"
+	intentDetermine   = "unable to determine transaction intent"
 )
 
 // Error represents an error as defined by the Rosetta API specification. It

--- a/api/rosetta/parser.go
+++ b/api/rosetta/parser.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package rosetta
+
+import (
+	"github.com/onflow/flow-go-sdk"
+
+	"github.com/optakt/flow-dps/rosetta/identifier"
+	"github.com/optakt/flow-dps/rosetta/object"
+	"github.com/optakt/flow-dps/rosetta/transactions"
+)
+
+// Parser is used by the Rosetta Construction API to handle transaction related operations.
+type Parser interface {
+	CreateTransactionIntent(operations []object.Operation) (intent *transactions.Intent, err error)
+	CreateTransaction(intent *transactions.Intent) (tx *flow.Transaction, err error)
+	ParseTransaction(tx flow.Transaction) (operations []object.Operation, signers []identifier.Account, err error)
+}

--- a/api/rosetta/preprocess.go
+++ b/api/rosetta/preprocess.go
@@ -84,7 +84,7 @@ func (c *Construction) Preprocess(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnprocessableEntity, invalidIntent(inErr))
 	}
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, internal(intentCreate, err))
+		return echo.NewHTTPError(http.StatusBadRequest, internal(intentDetermine, err))
 	}
 
 	res := PreprocessResponse{

--- a/api/rosetta/preprocess.go
+++ b/api/rosetta/preprocess.go
@@ -1,0 +1,99 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package rosetta
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/optakt/flow-dps/rosetta/failure"
+	"github.com/optakt/flow-dps/rosetta/identifier"
+	"github.com/optakt/flow-dps/rosetta/object"
+)
+
+// PreprocessRequest implements the request schema for /construction/preprocess.
+// See https://www.rosetta-api.org/docs/ConstructionApi.html#request-6
+type PreprocessRequest struct {
+	NetworkID  identifier.Network `json:"network_identifier"`
+	Operations []object.Operation `json:"operations"`
+}
+
+// PreprocessResponse implements the response schema for /construction/preprocess.
+// See https://www.rosetta-api.org/docs/ConstructionApi.html#response-6
+type PreprocessResponse struct {
+	object.Options `json:"options,omitempty"`
+}
+
+// Preprocess implements the /construction/preprocess endpoint of the Rosetta Construction API.
+// Preprocess receives a list of operations that should deterministically specify the
+// intent of the transaction. Preprocess endpoint returns the `options` object that
+// will be sent **unmodified** to /construction/metadata, effectively creating the metadata
+// request.
+// See https://www.rosetta-api.org/docs/ConstructionApi.html#constructionpreprocess
+func (c *Construction) Preprocess(ctx echo.Context) error {
+
+	var req PreprocessRequest
+	err := ctx.Bind(&req)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, invalidEncoding(invalidJSON, err))
+	}
+
+	if req.NetworkID.Blockchain == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, invalidFormat(blockchainEmpty))
+	}
+	if req.NetworkID.Network == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, invalidFormat(networkEmpty))
+	}
+
+	if len(req.Operations) != 2 {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			invalidFormat(txInvalidOpCount,
+				withDetail("have_operations", len(req.Operations))),
+		)
+	}
+
+	intent, err := c.parser.CreateTransactionIntent(req.Operations)
+	var iaErr failure.InvalidAccount
+	if errors.As(err, &iaErr) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, invalidAccount(iaErr))
+	}
+	var icErr failure.InvalidCurrency
+	if errors.As(err, &icErr) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, invalidCurrency(icErr))
+	}
+	var ucErr failure.UnknownCurrency
+	if errors.As(err, &ucErr) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, unknownCurrency(ucErr))
+	}
+	var inErr failure.InvalidIntent
+	if errors.As(err, &inErr) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, invalidIntent(inErr))
+	}
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, internal(intentCreate, err))
+	}
+
+	res := PreprocessResponse{
+		Options: object.Options{
+			AccountID: identifier.Account{
+				Address: intent.From.Hex(),
+			},
+		},
+	}
+
+	return ctx.JSON(http.StatusOK, res)
+}

--- a/cmd/flow-rosetta-server/main.go
+++ b/cmd/flow-rosetta-server/main.go
@@ -71,7 +71,7 @@ func run() int {
 	)
 
 	pflag.StringVarP(&flagDPSAPI, "api", "a", "127.0.0.1:5005", "host URL for GRPC API endpoint")
-	pflag.StringVarP(&flagFlowAPI, "flow-api", "f", "", "host URL for Flow Access API endpoint")
+	pflag.StringVarP(&flagFlowAPI, "flow-api", "f", "", "host URL for Flow network's Access API endpoint")
 	pflag.Uint64VarP(&flagCache, "cache", "e", uint64(datasize.GB), "maximum cache size for register reads in bytes")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 	pflag.Uint16VarP(&flagPort, "port", "p", 8080, "port to host Rosetta API on")

--- a/cmd/flow-rosetta-server/main.go
+++ b/cmd/flow-rosetta-server/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/c2h5oh/datasize"
 	"github.com/labstack/echo/v4"
+	"github.com/onflow/flow-go-sdk/client"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 	"github.com/ziflex/lecho/v2"
@@ -39,6 +40,7 @@ import (
 	"github.com/optakt/flow-dps/rosetta/invoker"
 	"github.com/optakt/flow-dps/rosetta/retriever"
 	"github.com/optakt/flow-dps/rosetta/scripts"
+	"github.com/optakt/flow-dps/rosetta/transactions"
 	"github.com/optakt/flow-dps/rosetta/validator"
 )
 
@@ -59,14 +61,16 @@ func run() int {
 
 	// Command line parameter initialization.
 	var (
-		flagAPI          string
+		flagDPSAPI       string
+		flagFlowAPI      string
 		flagCache        uint64
 		flagLevel        string
 		flagPort         uint16
 		flagTransactions uint
 	)
 
-	pflag.StringVarP(&flagAPI, "api", "a", "127.0.0.1:5005", "host URL for GRPC API endpoint")
+	pflag.StringVarP(&flagDPSAPI, "api", "a", "127.0.0.1:5005", "host URL for GRPC API endpoint")
+	pflag.StringVarP(&flagFlowAPI, "flow-api", "f", "", "host URL for Flow Access API endpoint")
 	pflag.Uint64VarP(&flagCache, "cache", "e", uint64(datasize.GB), "maximum cache size for register reads in bytes")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 	pflag.Uint16VarP(&flagPort, "port", "p", 8080, "port to host Rosetta API on")
@@ -93,14 +97,14 @@ func run() int {
 	}
 
 	// Initialize the DPS API client and wrap it for easy usage.
-	conn, err := grpc.Dial(flagAPI, grpc.WithInsecure())
+	conn, err := grpc.Dial(flagDPSAPI, grpc.WithInsecure())
 	if err != nil {
-		log.Error().Str("api", flagAPI).Err(err).Msg("could not dial API host")
+		log.Error().Str("api", flagDPSAPI).Err(err).Msg("could not dial API host")
 		return failure
 	}
 	defer conn.Close()
-	client := api.NewAPIClient(conn)
-	index := api.IndexFromAPI(client, codec)
+	dpsClient := api.NewAPIClient(conn)
+	index := api.IndexFromAPI(dpsClient, codec)
 
 	// Deduce chain ID from DPS API to configure parameters for script exec.
 	first, err := index.First()
@@ -118,6 +122,20 @@ func run() int {
 		log.Error().Str("chain", root.ChainID.String()).Msg("invalid chain ID for params")
 		return failure
 	}
+
+	// Initialize the SDK client.
+
+	if flagFlowAPI == "" {
+		log.Error().Msg("Flow API endpoint is missing")
+		return failure
+	}
+
+	flowClient, err := client.New(flagFlowAPI, grpc.WithInsecure())
+	if err != nil {
+		log.Error().Str("api", flagFlowAPI).Err(err).Msg("could not dial Flow API host")
+		return failure
+	}
+	defer flowClient.Close()
 
 	// Rosetta API initialization.
 	config := configuration.New(params.ChainID)
@@ -138,19 +156,25 @@ func run() int {
 	retrieve := retriever.New(params, index, validate, generate, invoke, convert,
 		retriever.WithTransactionLimit(flagTransactions),
 	)
-	ctrl := rosetta.NewData(config, retrieve)
+	dataCtrl := rosetta.NewData(config, retrieve)
+
+	parser := transactions.NewParser(validate, generate)
+	constructCtrl := rosetta.NewConstruction(config, parser, retrieve, flowClient)
 
 	server := echo.New()
 	server.HideBanner = true
 	server.HidePort = true
 	server.Logger = elog
 	server.Use(lecho.Middleware(lecho.Config{Logger: elog}))
-	server.POST("/network/list", ctrl.Networks)
-	server.POST("/network/options", ctrl.Options)
-	server.POST("/network/status", ctrl.Status)
-	server.POST("/account/balance", ctrl.Balance)
-	server.POST("/block", ctrl.Block)
-	server.POST("/block/transaction", ctrl.Transaction)
+	server.POST("/network/list", dataCtrl.Networks)
+	server.POST("/network/options", dataCtrl.Options)
+	server.POST("/network/status", dataCtrl.Status)
+	server.POST("/account/balance", dataCtrl.Balance)
+	server.POST("/block", dataCtrl.Block)
+	server.POST("/block/transaction", dataCtrl.Transaction)
+
+	// This group contains all of the Rosetta Construction API endpoints.
+	server.POST("/construction/preprocess", constructCtrl.Preprocess)
 
 	// This section launches the main executing components in their own
 	// goroutine, so they can run concurrently. Afterwards, we wait for an

--- a/cmd/flow-rosetta-server/main.go
+++ b/cmd/flow-rosetta-server/main.go
@@ -25,11 +25,12 @@ import (
 
 	"github.com/c2h5oh/datasize"
 	"github.com/labstack/echo/v4"
-	"github.com/onflow/flow-go-sdk/client"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 	"github.com/ziflex/lecho/v2"
 	"google.golang.org/grpc"
+
+	"github.com/onflow/flow-go-sdk/client"
 
 	api "github.com/optakt/flow-dps/api/dps"
 	"github.com/optakt/flow-dps/api/rosetta"

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/labstack/echo/v4 v4.3.0
 	github.com/onflow/cadence v0.16.1
 	github.com/onflow/flow-go v0.17.6
+	github.com/onflow/flow-go-sdk v0.20.0-alpha.1 // indirect
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/rs/zerolog v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -792,6 +792,7 @@ github.com/onflow/flow-go-sdk v0.20.0-alpha.1/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4J
 github.com/onflow/flow-go/crypto v0.12.0 h1:TMsqn5nsW4vrCIFG/HRE/oy/a5/sffHrDRDYqicwO98=
 github.com/onflow/flow-go/crypto v0.12.0/go.mod h1:oXuvU0Dr4lHKgye6nHEFbBXIWNv+dBQUzoVW5Go38+o=
 github.com/onflow/flow/protobuf/go/flow v0.1.9/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
+github.com/onflow/flow/protobuf/go/flow v0.2.0 h1:a4Cg0ekoqb76zeOEo1wtSWtlnhGXwcxebp0itFwGtlE=
 github.com/onflow/flow/protobuf/go/flow v0.2.0/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/models/convert/cadence.go
+++ b/models/convert/cadence.go
@@ -197,14 +197,16 @@ func ParseRosettaValue(value string) (cadence.UFix64, error) {
 	// If the number is shorter, it means that the whole string is the fraction.
 	if len(value) > dps.FlowDecimals {
 
+		decimalsIndex := len(value) - dps.FlowDecimals
+
 		// Get all characters except the last 8 and convert that string to an integer.
-		decimal, err = strconv.ParseInt(value[:len(value)-dps.FlowDecimals], 10, 32)
+		decimal, err = strconv.ParseInt(value[:decimalsIndex], 10, 32)
 		if err != nil {
 			return 0, fmt.Errorf("could not parse decimal part: %w", err)
 		}
 
 		// Get the last 8 characters and convert them to an uint.
-		fraction, err = strconv.ParseUint(value[len(value)-dps.FlowDecimals:], 10, 32)
+		fraction, err = strconv.ParseUint(value[decimalsIndex:], 10, 32)
 		if err != nil {
 			return 0, fmt.Errorf("could not parse fraction part: %w", err)
 		}

--- a/models/convert/cadence.go
+++ b/models/convert/cadence.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 
 	"github.com/onflow/cadence"
+
 	"github.com/optakt/flow-dps/models/dps"
 )
 

--- a/rosetta/configuration/errors.go
+++ b/rosetta/configuration/errors.go
@@ -19,15 +19,16 @@ import (
 )
 
 var (
-	ErrorInternal           = meta.ErrorDefinition{Code: 1, Message: "internal error", Retriable: false}
-	ErrorInvalidEncoding    = meta.ErrorDefinition{Code: 2, Message: "invalid request encoding", Retriable: false}
-	ErrorInvalidFormat      = meta.ErrorDefinition{Code: 3, Message: "invalid request format", Retriable: false}
-	ErrorInvalidNetwork     = meta.ErrorDefinition{Code: 4, Message: "invalid network identifier", Retriable: false}
-	ErrorInvalidAccount     = meta.ErrorDefinition{Code: 5, Message: "invalid account identifier", Retriable: false}
-	ErrorInvalidCurrency    = meta.ErrorDefinition{Code: 6, Message: "invalid currency identifier", Retriable: false}
-	ErrorInvalidBlock       = meta.ErrorDefinition{Code: 7, Message: "invalid block identifier", Retriable: false}
-	ErrorInvalidTransaction = meta.ErrorDefinition{Code: 8, Message: "invalid transaction identifier", Retriable: false}
-	ErrorUnknownBlock       = meta.ErrorDefinition{Code: 9, Message: "unknown block identifier", Retriable: true}
-	ErrorUnknownCurrency    = meta.ErrorDefinition{Code: 10, Message: "unknown currency identifier", Retriable: false}
-	ErrorUnknownTransaction = meta.ErrorDefinition{Code: 11, Message: "unknown block transaction", Retriable: false}
+	ErrorInternal                 = meta.ErrorDefinition{Code: 1, Message: "internal error", Retriable: false}
+	ErrorInvalidEncoding          = meta.ErrorDefinition{Code: 2, Message: "invalid request encoding", Retriable: false}
+	ErrorInvalidFormat            = meta.ErrorDefinition{Code: 3, Message: "invalid request format", Retriable: false}
+	ErrorInvalidNetwork           = meta.ErrorDefinition{Code: 4, Message: "invalid network identifier", Retriable: false}
+	ErrorInvalidAccount           = meta.ErrorDefinition{Code: 5, Message: "invalid account identifier", Retriable: false}
+	ErrorInvalidCurrency          = meta.ErrorDefinition{Code: 6, Message: "invalid currency identifier", Retriable: false}
+	ErrorInvalidBlock             = meta.ErrorDefinition{Code: 7, Message: "invalid block identifier", Retriable: false}
+	ErrorInvalidTransaction       = meta.ErrorDefinition{Code: 8, Message: "invalid transaction identifier", Retriable: false}
+	ErrorUnknownBlock             = meta.ErrorDefinition{Code: 9, Message: "unknown block identifier", Retriable: true}
+	ErrorUnknownCurrency          = meta.ErrorDefinition{Code: 10, Message: "unknown currency identifier", Retriable: false}
+	ErrorUnknownTransaction       = meta.ErrorDefinition{Code: 11, Message: "unknown block transaction", Retriable: false}
+	ErrorInvalidTransactionIntent = meta.ErrorDefinition{Code: 12, Message: "invalid transaction intent", Retriable: false}
 )

--- a/rosetta/failure/invalid_intent.go
+++ b/rosetta/failure/invalid_intent.go
@@ -1,0 +1,32 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package failure
+
+import (
+	"fmt"
+)
+
+type InvalidIntent struct {
+	Description Description
+	Sender      string
+	Receiver    string
+}
+
+func (i InvalidIntent) Error() string {
+	return fmt.Sprintf("invalid transaction intent (from: %s, to: %s): %s",
+		i.Sender,
+		i.Receiver,
+		i.Description)
+}

--- a/rosetta/object/options.go
+++ b/rosetta/object/options.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package object
+
+import (
+	"github.com/optakt/flow-dps/rosetta/identifier"
+)
+
+// Options object is used in the Rosetta Construction API requests.
+// This object is returned in the `/construction/preprocess` response,
+// and is forwarded to the `/construction/metadata` endpoint unmodified.
+//
+// Specifically for Flow DPS, this object contains the account identifier
+// that is the proposer of the transaction (by default, this is the sender).
+// Account identifier is required so that we can return the sequence number
+// of the proposer's key, required for the Flow transaction.
+type Options struct {
+	AccountID identifier.Account `json:"account_identifier"`
+}

--- a/rosetta/transactions/create_transaction.go
+++ b/rosetta/transactions/create_transaction.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package transactions
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go-sdk"
+)
+
+// CreateTransaction translates the transaction intent to the Flow Transaction struct.
+func (p *Parser) CreateTransaction(intent *Intent) (*flow.Transaction, error) {
+	return nil, fmt.Errorf("TBD - not implemented")
+}

--- a/rosetta/transactions/generator.go
+++ b/rosetta/transactions/generator.go
@@ -1,0 +1,19 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package transactions
+
+type Generator interface {
+	TransferTokens(symbol string) ([]byte, error)
+}

--- a/rosetta/transactions/intent.go
+++ b/rosetta/transactions/intent.go
@@ -122,6 +122,7 @@ func (p *Parser) CreateTransactionIntent(operations []object.Operation) (*Intent
 			),
 		}
 	}
+
 	// Parse value specified by the receiver.
 	rv, err := convert.ParseRosettaValue(receive.Amount.Value)
 	if err != nil {

--- a/rosetta/transactions/intent.go
+++ b/rosetta/transactions/intent.go
@@ -1,0 +1,171 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package transactions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/flow-go/model/flow"
+
+	"github.com/optakt/flow-dps/models/convert"
+	"github.com/optakt/flow-dps/models/dps"
+	"github.com/optakt/flow-dps/rosetta/failure"
+	"github.com/optakt/flow-dps/rosetta/object"
+)
+
+// Intent describes the intent of an array of Rosetta operations.
+type Intent struct {
+	From     flow.Address
+	To       flow.Address
+	Amount   cadence.UFix64
+	Payer    flow.Address
+	Proposer flow.Address
+
+	ReferenceBlock            flow.Identifier
+	ProposerKeySequenceNumber uint64
+	GasLimit                  uint64
+}
+
+// CreateTransactionIntent creates a transaction Intent from two operations given as input.
+// Specified operations should be symmetrical, a deposit and a withdrawal from two
+// different accounts. At the moment, the only fields taken into account are the
+// account IDs, amounts and type of operation.
+func (p *Parser) CreateTransactionIntent(operations []object.Operation) (*Intent, error) {
+
+	// Operations are invalid if both operations have negative amounts.
+	if strings.HasPrefix(operations[0].Amount.Value, "-") &&
+		strings.HasPrefix(operations[1].Amount.Value, "-") {
+
+		return nil, failure.InvalidIntent{
+			Description: failure.NewDescription("invalid operations - two deposits specified"),
+			Sender:      operations[0].AccountID.Address,
+			Receiver:    operations[1].AccountID.Address,
+		}
+	}
+
+	// Operations are also invalid if both operations have positive amounts.
+	if !strings.HasPrefix(operations[0].Amount.Value, "-") &&
+		!strings.HasPrefix(operations[1].Amount.Value, "-") {
+
+		return nil, failure.InvalidIntent{
+			Description: failure.NewDescription("invalid operations - two withdrawals specified"),
+			Sender:      operations[0].AccountID.Address,
+			Receiver:    operations[1].AccountID.Address,
+		}
+	}
+
+	send := operations[0]
+	receive := operations[1]
+
+	// If the send operation doesn't have the negative value, we should switch the operations.
+	if !strings.HasPrefix(send.Amount.Value, "-") {
+		receive = operations[0]
+		send = operations[1]
+	}
+
+	// Validate the sender and the receiver account IDs.
+	err := p.validate.Account(send.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid sender account: %w", err)
+	}
+	err = p.validate.Account(receive.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid receiver account: %w", err)
+	}
+
+	// Validate the currencies specified for deposit and withdrawal.
+	send.Amount.Currency, err = p.validate.Currency(send.Amount.Currency)
+	if err != nil {
+		return nil, fmt.Errorf("invalid sender currency: %w", err)
+	}
+	receive.Amount.Currency, err = p.validate.Currency(receive.Amount.Currency)
+	if err != nil {
+		return nil, fmt.Errorf("invalid receiver currency: %w", err)
+	}
+
+	// Make sure that both the send and receive operations use the same currency.
+	// This is perhaps unnecessary at the moment since we only have a single currency.
+	if send.Amount.Currency != receive.Amount.Currency {
+		return nil, failure.InvalidIntent{
+			Sender:      send.AccountID.Address,
+			Receiver:    receive.AccountID.Address,
+			Description: failure.NewDescription("send and receive currencies do not match"),
+		}
+	}
+
+	// Parse value specified by the sender, after removing the negative sign prefix.
+	trimmed := strings.TrimPrefix(send.Amount.Value, "-")
+	sv, err := convert.ParseRosettaValue(trimmed)
+	if err != nil {
+		return nil, failure.InvalidIntent{
+			Sender:   send.AccountID.Address,
+			Receiver: receive.AccountID.Address,
+			Description: failure.NewDescription("could not parse withdrawal amount",
+				failure.WithString("withdrawal_amount", send.Amount.Value),
+				failure.WithErr(err),
+			),
+		}
+	}
+	// Parse value specified by the receiver.
+	rv, err := convert.ParseRosettaValue(receive.Amount.Value)
+	if err != nil {
+		return nil, failure.InvalidIntent{
+			Sender:   send.AccountID.Address,
+			Receiver: receive.AccountID.Address,
+			Description: failure.NewDescription("could not parse deposit amount",
+				failure.WithString("deposit_amount", receive.Amount.Value),
+				failure.WithErr(err),
+			),
+		}
+	}
+
+	// Check if the specified amounts match.
+	if sv != rv {
+		return nil, failure.InvalidIntent{
+			Sender:   send.AccountID.Address,
+			Receiver: receive.AccountID.Address,
+			Description: failure.NewDescription("deposit and withdrawal amounts do not match",
+				failure.WithString("deposit_amount", receive.Amount.Value),
+				failure.WithString("withdrawal_amount", send.Amount.Value),
+			),
+		}
+	}
+
+	// Validate that the specified operations are transfers.
+	if strings.ToUpper(send.Type) != dps.OperationTransfer ||
+		strings.ToUpper(receive.Type) != dps.OperationTransfer {
+
+		return nil, failure.InvalidIntent{
+			Sender:   send.AccountID.Address,
+			Receiver: receive.AccountID.Address,
+			Description: failure.NewDescription("only transfer operations are supported",
+				failure.WithString("deposit_type", receive.Type),
+				failure.WithString("withdrawal_type", send.Type),
+			),
+		}
+	}
+
+	intent := Intent{
+		From:     flow.HexToAddress(send.AccountID.Address),
+		To:       flow.HexToAddress(receive.AccountID.Address),
+		Amount:   sv,
+		Payer:    flow.HexToAddress(send.AccountID.Address),
+		Proposer: flow.HexToAddress(send.AccountID.Address),
+	}
+
+	return &intent, nil
+}

--- a/rosetta/transactions/parse_transaction.go
+++ b/rosetta/transactions/parse_transaction.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package transactions
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go-sdk"
+
+	"github.com/optakt/flow-dps/rosetta/identifier"
+	"github.com/optakt/flow-dps/rosetta/object"
+)
+
+// ParseTransactions processes the flow transaction and translates it to a list of operations and a list of
+// signers.
+func (p *Parser) ParseTransaction(tx flow.Transaction) ([]object.Operation, []identifier.Account, error) {
+	return nil, nil, fmt.Errorf("TBD: not implemented")
+}

--- a/rosetta/transactions/parser.go
+++ b/rosetta/transactions/parser.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package transactions
+
+// Parser has the capabilities to determine transaction intent from an array
+// of Rosetta operations, create a Flow transaction from a transaction intent
+// and transate a Flow transaction back to an array of Rosetta operations.
+type Parser struct {
+	validate Validator
+	generate Generator
+}
+
+// NewParser creates a new transaction Parser to handle constructing
+// and parsing transactions.
+func NewParser(validate Validator, generate Generator) *Parser {
+
+	p := Parser{
+		validate: validate,
+		generate: generate,
+	}
+
+	return &p
+}

--- a/rosetta/transactions/validator.go
+++ b/rosetta/transactions/validator.go
@@ -1,0 +1,24 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package transactions
+
+import (
+	"github.com/optakt/flow-dps/rosetta/identifier"
+)
+
+type Validator interface {
+	Account(address identifier.Account) error
+	Currency(currency identifier.Currency) (identifier.Currency, error)
+}


### PR DESCRIPTION
## Goal of this PR

Fixes #288.

This PR introduces the basis for the Rosetta Construction API. I have included most of the basic functionality for the API. Some functionalities don't not come into play yet, like the Access API client (used for the `submit` endpoint), but I did not want to artificially change the interfaces to simulate some gradual evolution, as this was all done already.

For some parts that exist but are not relevant for this PR, I've added placeholders (transaction parser methods that create and parse transactions).

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [ ] ~Tests are up-to-date~