### PR TITLE
Improvements for snapshot tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /cmd/check-duplicate-transactions/check-duplicate-transactions
 /cmd/create-index-snapshot/create-index-snapshot
+/cmd/restore-index-snapshot/restore-index-snapshot
+/cmd/extract-block-events/extract-block-events
+/cmd/extract-block-headers/extract-block-headers
+/cmd/extract-ledger-payloads/extract-ledger-payloads
 /cmd/flow-dps-client/flow-dps-client
 /cmd/flow-dps-indexer/flow-dps-indexer
 /cmd/flow-rosetta-server/flow-rosetta-server

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,11 @@
 /cmd/check-duplicate-transactions/check-duplicate-transactions
 /cmd/create-index-snapshot/create-index-snapshot
-/cmd/restore-index-snapshot/restore-index-snapshot
-/cmd/extract-block-events/extract-block-events
-/cmd/extract-block-headers/extract-block-headers
-/cmd/extract-ledger-payloads/extract-ledger-payloads
+/cmd/flow-access-server/flow-access-server
 /cmd/flow-dps-client/flow-dps-client
 /cmd/flow-dps-indexer/flow-dps-indexer
-/cmd/flow-rosetta-server/flow-rosetta-server
 /cmd/flow-dps-server/flow-dps-server
+/cmd/flow-rosetta-server/flow-rosetta-server
+/cmd/restore-index-snapshot/restore-index-snapshot
 /data/
 /index/
 /trie/

--- a/api/dps/server_integration_test.go
+++ b/api/dps/server_integration_test.go
@@ -39,8 +39,7 @@ func TestIntegrationServer_GetFirst(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -64,8 +63,7 @@ func TestIntegrationServer_GetFirst(t *testing.T) {
 	t.Run("handles indexer failure on First", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -77,7 +75,7 @@ func TestIntegrationServer_GetFirst(t *testing.T) {
 		server := dps.NewServer(reader, codec)
 
 		req := &dps.GetFirstRequest{}
-		_, err = server.GetFirst(context.Background(), req)
+		_, err := server.GetFirst(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -88,8 +86,7 @@ func TestIntegrationServer_GetLast(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -113,8 +110,7 @@ func TestIntegrationServer_GetLast(t *testing.T) {
 	t.Run("handles indexer failure on Last", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -126,7 +122,7 @@ func TestIntegrationServer_GetLast(t *testing.T) {
 		server := dps.NewServer(reader, codec)
 
 		req := &dps.GetLastRequest{}
-		_, err = server.GetLast(context.Background(), req)
+		_, err := server.GetLast(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -138,8 +134,7 @@ func TestIntegrationServer_GetHeightForBlock(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -165,8 +160,7 @@ func TestIntegrationServer_GetHeightForBlock(t *testing.T) {
 	t.Run("handles indexer failure on HeightForBlock", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -180,7 +174,7 @@ func TestIntegrationServer_GetHeightForBlock(t *testing.T) {
 		req := &dps.GetHeightForBlockRequest{
 			BlockID: id[:],
 		}
-		_, err = server.GetHeightForBlock(context.Background(), req)
+		_, err := server.GetHeightForBlock(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -192,8 +186,7 @@ func TestIntegrationServer_GetCommit(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -220,8 +213,7 @@ func TestIntegrationServer_GetCommit(t *testing.T) {
 	t.Run("handles indexer failure on Commit", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -235,7 +227,7 @@ func TestIntegrationServer_GetCommit(t *testing.T) {
 		req := &dps.GetCommitRequest{
 			Height: mocks.GenericHeight,
 		}
-		_, err = server.GetCommit(context.Background(), req)
+		_, err := server.GetCommit(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -247,8 +239,7 @@ func TestIntegrationServer_GetHeader(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -278,8 +269,7 @@ func TestIntegrationServer_GetHeader(t *testing.T) {
 	t.Run("handles indexer failure on Header", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -293,7 +283,7 @@ func TestIntegrationServer_GetHeader(t *testing.T) {
 		req := &dps.GetHeaderRequest{
 			Height: mocks.GenericHeight,
 		}
-		_, err = server.GetHeader(context.Background(), req)
+		_, err := server.GetHeader(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -306,8 +296,7 @@ func TestIntegrationServer_GetEvents(t *testing.T) {
 	t.Run("nominal case without type specified", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -339,8 +328,7 @@ func TestIntegrationServer_GetEvents(t *testing.T) {
 	t.Run("nominal case with type specified", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -380,8 +368,7 @@ func TestIntegrationServer_GetEvents(t *testing.T) {
 	t.Run("handles indexer failure on Events", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -395,7 +382,7 @@ func TestIntegrationServer_GetEvents(t *testing.T) {
 		req := &dps.GetEventsRequest{
 			Height: height,
 		}
-		_, err = server.GetEvents(context.Background(), req)
+		_, err := server.GetEvents(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -409,8 +396,7 @@ func TestIntegrationServer_GetRegisterValues(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -445,8 +431,7 @@ func TestIntegrationServer_GetRegisterValues(t *testing.T) {
 	t.Run("handles conversion error", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -466,7 +451,7 @@ func TestIntegrationServer_GetRegisterValues(t *testing.T) {
 			Height: height,
 			Paths:  [][]byte{mocks.GenericBytes},
 		}
-		_, err = server.GetRegisterValues(context.Background(), req)
+		_, err := server.GetRegisterValues(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -474,8 +459,7 @@ func TestIntegrationServer_GetRegisterValues(t *testing.T) {
 	t.Run("handles indexer failure on Values", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -490,7 +474,7 @@ func TestIntegrationServer_GetRegisterValues(t *testing.T) {
 			Height: height,
 			Paths:  [][]byte{mocks.GenericBytes},
 		}
-		_, err = server.GetRegisterValues(context.Background(), req)
+		_, err := server.GetRegisterValues(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -503,8 +487,7 @@ func TestIntegrationServer_GetCollection(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -534,8 +517,7 @@ func TestIntegrationServer_GetCollection(t *testing.T) {
 	t.Run("handles indexer failure on Collection", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -549,7 +531,7 @@ func TestIntegrationServer_GetCollection(t *testing.T) {
 		req := &dps.GetCollectionRequest{
 			CollectionID: collID[:],
 		}
-		_, err = server.GetCollection(context.Background(), req)
+		_, err := server.GetCollection(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -562,8 +544,7 @@ func TestIntegrationServer_ListCollectionsForHeight(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -595,8 +576,7 @@ func TestIntegrationServer_ListCollectionsForHeight(t *testing.T) {
 	t.Run("handles indexer failure on CollectionsByHeight", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -610,7 +590,7 @@ func TestIntegrationServer_ListCollectionsForHeight(t *testing.T) {
 		req := &dps.ListCollectionsForHeightRequest{
 			Height: mocks.GenericHeight,
 		}
-		_, err = server.ListCollectionsForHeight(context.Background(), req)
+		_, err := server.ListCollectionsForHeight(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -623,8 +603,7 @@ func TestIntegrationServer_GetGuarantee(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -654,8 +633,7 @@ func TestIntegrationServer_GetGuarantee(t *testing.T) {
 	t.Run("handles indexer failure on Guarantee", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -669,7 +647,7 @@ func TestIntegrationServer_GetGuarantee(t *testing.T) {
 		req := &dps.GetGuaranteeRequest{
 			CollectionID: collID[:],
 		}
-		_, err = server.GetGuarantee(context.Background(), req)
+		_, err := server.GetGuarantee(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -682,8 +660,7 @@ func TestIntegrationServer_GetTransaction(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -713,8 +690,7 @@ func TestIntegrationServer_GetTransaction(t *testing.T) {
 	t.Run("handles indexer failure on Transaction", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -728,7 +704,7 @@ func TestIntegrationServer_GetTransaction(t *testing.T) {
 		req := &dps.GetTransactionRequest{
 			TransactionID: txID[:],
 		}
-		_, err = server.GetTransaction(context.Background(), req)
+		_, err := server.GetTransaction(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -741,8 +717,7 @@ func TestIntegrationServer_GetHeightForTransaction(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -769,8 +744,7 @@ func TestIntegrationServer_GetHeightForTransaction(t *testing.T) {
 	t.Run("handles indexer failure on HeightForTransaction", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -784,7 +758,7 @@ func TestIntegrationServer_GetHeightForTransaction(t *testing.T) {
 		req := &dps.GetHeightForTransactionRequest{
 			TransactionID: txID[:],
 		}
-		_, err = server.GetHeightForTransaction(context.Background(), req)
+		_, err := server.GetHeightForTransaction(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -797,8 +771,7 @@ func TestIntegrationServer_ListTransactionsForHeight(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -830,8 +803,7 @@ func TestIntegrationServer_ListTransactionsForHeight(t *testing.T) {
 	t.Run("handles indexer failure on TransactionsByHeight", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -845,7 +817,7 @@ func TestIntegrationServer_ListTransactionsForHeight(t *testing.T) {
 		req := &dps.ListTransactionsForHeightRequest{
 			Height: mocks.GenericHeight,
 		}
-		_, err = server.ListTransactionsForHeight(context.Background(), req)
+		_, err := server.ListTransactionsForHeight(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -858,8 +830,7 @@ func TestIntegrationServer_GetResult(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -889,8 +860,7 @@ func TestIntegrationServer_GetResult(t *testing.T) {
 	t.Run("handles indexer failure on Result", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -904,7 +874,7 @@ func TestIntegrationServer_GetResult(t *testing.T) {
 		req := &dps.GetResultRequest{
 			TransactionID: txID[:],
 		}
-		_, err = server.GetResult(context.Background(), req)
+		_, err := server.GetResult(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -917,8 +887,7 @@ func TestIntegrationServer_GetSeal(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -948,8 +917,7 @@ func TestIntegrationServer_GetSeal(t *testing.T) {
 	t.Run("handles indexer failure on Seal", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -963,7 +931,7 @@ func TestIntegrationServer_GetSeal(t *testing.T) {
 		req := &dps.GetSealRequest{
 			SealID: sealID[:],
 		}
-		_, err = server.GetSeal(context.Background(), req)
+		_, err := server.GetSeal(context.Background(), req)
 
 		assert.Error(t, err)
 	})
@@ -976,8 +944,7 @@ func TestIntegrationServer_ListSealsForHeight(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -1009,8 +976,7 @@ func TestIntegrationServer_ListSealsForHeight(t *testing.T) {
 	t.Run("handles indexer failure on SealsByHeight", func(t *testing.T) {
 		t.Parallel()
 
-		codec, err := zbor.NewCodec()
-		require.NoError(t, err)
+		codec := zbor.NewCodec()
 
 		db := helpers.InMemoryDB(t)
 
@@ -1024,7 +990,7 @@ func TestIntegrationServer_ListSealsForHeight(t *testing.T) {
 		req := &dps.ListSealsForHeightRequest{
 			Height: mocks.GenericHeight,
 		}
-		_, err = server.ListSealsForHeight(context.Background(), req)
+		_, err := server.ListSealsForHeight(context.Background(), req)
 
 		assert.Error(t, err)
 	})

--- a/api/rosetta/data_integration_test.go
+++ b/api/rosetta/data_integration_test.go
@@ -93,8 +93,7 @@ func setupDB(t *testing.T) *badger.DB {
 func setupAPI(t *testing.T, db *badger.DB) *rosetta.Data {
 	t.Helper()
 
-	codec, err := zbor.NewCodec()
-	require.NoError(t, err)
+	codec := zbor.NewCodec()
 	storage := storage.New(codec)
 	index := index.NewReader(db, storage)
 

--- a/cmd/check-duplicate-transactions/comparison.go
+++ b/cmd/check-duplicate-transactions/comparison.go
@@ -45,8 +45,7 @@ func compareDuplicates(log zerolog.Logger, dataDir string, indexDir string, dupl
 	defer index.Close()
 
 	// Initialize the storage library.
-	codec, _ := zbor.NewCodec()
-	lib := storage.New(codec)
+	lib := storage.New(zbor.NewCodec())
 
 	// Go through duplicates and compare number and IDs of duplicates beetween databases.
 	for height, duplicateIDs := range duplicates {

--- a/cmd/check-duplicate-transactions/comparison.go
+++ b/cmd/check-duplicate-transactions/comparison.go
@@ -33,12 +33,12 @@ func compareDuplicates(log zerolog.Logger, dataDir string, indexDir string, dupl
 	log.Info().Msg("comparing duplicates between databases")
 
 	// Initialize the databases.
-	protocol, err := badger.Open(dps.DefaultOptions(dataDir).WithReadOnly(true).WithBypassLockGuard(true))
+	protocol, err := badger.Open(dps.DefaultOptions(dataDir).WithReadOnly(true))
 	if err != nil {
 		return fmt.Errorf("could not open protocol state (dir: %s): %w", dataDir, err)
 	}
 	defer protocol.Close()
-	index, err := badger.Open(dps.DefaultOptions(indexDir).WithReadOnly(true).WithBypassLockGuard(true))
+	index, err := badger.Open(dps.DefaultOptions(indexDir).WithReadOnly(true))
 	if err != nil {
 		return fmt.Errorf("could not open state index (dir: %s): %w", indexDir, err)
 	}

--- a/cmd/check-duplicate-transactions/index.go
+++ b/cmd/check-duplicate-transactions/index.go
@@ -36,7 +36,7 @@ func indexCheck(log zerolog.Logger, dir string) (map[uint64][]flow.Identifier, e
 	log.Info().Str("index", dir).Msg("starting index state duplicate check")
 
 	// Open the index database.
-	index, err := badger.Open(dps.DefaultOptions(dir).WithReadOnly(true).WithBypassLockGuard(true))
+	index, err := badger.Open(dps.DefaultOptions(dir).WithReadOnly(true))
 	if err != nil {
 		return nil, fmt.Errorf("could not open state index (dir: %s): %w", dir, err)
 	}

--- a/cmd/check-duplicate-transactions/index.go
+++ b/cmd/check-duplicate-transactions/index.go
@@ -43,8 +43,7 @@ func indexCheck(log zerolog.Logger, dir string) (map[uint64][]flow.Identifier, e
 	defer index.Close()
 
 	// Initialize the storage library.
-	codec, _ := zbor.NewCodec()
-	lib := storage.New(codec)
+	lib := storage.New(zbor.NewCodec())
 
 	// Retrieve the root height as a start height for duplicate check.
 	var first uint64

--- a/cmd/check-duplicate-transactions/protocol.go
+++ b/cmd/check-duplicate-transactions/protocol.go
@@ -33,7 +33,7 @@ func protocolCheck(log zerolog.Logger, dir string) error {
 	log.Info().Str("data", dir).Msg("starting protocol state duplicate check")
 
 	// Open the protocol state database.
-	protocol, err := badger.Open(dps.DefaultOptions(dir).WithReadOnly(true).WithBypassLockGuard(true))
+	protocol, err := badger.Open(dps.DefaultOptions(dir).WithReadOnly(true))
 	if err != nil {
 		return fmt.Errorf("could not open protocol state (dir: %s): %w", dir, err)
 	}

--- a/cmd/create-index-snapshot/README.md
+++ b/cmd/create-index-snapshot/README.md
@@ -4,11 +4,8 @@
 
 This utility binary creates snapshots of existing indexes.
 When a path to the index (badger database) is specified, the badger API is used to create a backup. 
-This backup is written to the standard output or to a `gzip` archive if the `output` option is specified.
+This backup is written to the standard output, using the format specified by the `format` argument.
 This backup is compressed with Zstandard compression.
-
-Output argument can either be a directory, or a full path to the `.gz` file that will be created.
-If the `output` argument is a directory, a timestamped file will be created (example of a name is `flow-dps-snapshot-03-08-2021-11-02.gz`).
 
 This output can be used to restore a database from a previous snapshot by a `restore-index-snapshot` tool.
 
@@ -16,10 +13,9 @@ This output can be used to restore a database from a previous snapshot by a `res
 
 ```sh
 Usage of create-index-snapshot:
+  -f, --format string   output format (hex, gzip or raw) (default "raw")
   -i, --index string    database directory for state index (default "index")
   -l, --level string    log output level (default "info")
-      --output string   output archive for snapshot
-  -r, --raw             use raw binary output instead of hexadecimal when using stdout
 ```
 
 ## Examples
@@ -29,22 +25,15 @@ Usage of create-index-snapshot:
 Backup index to a hex-encoded string:
 
 ```console
-$ create-index-snapshot -i index > snapshot.hex
+$ create-index-snapshot -i index --format hex > snapshot.hex
 ```
 
 Backup index to a file named `dps-backup.gz` in the `/tmp` directory:
 
 ```console
-$ create-index-snapshot -i index --output /tmp/dps-backup.gz
+$ create-index-snapshot -i index --format gzip > /tmp/dps-backup.gz
 ```
 
-Backup index to a `/var/tmp` directory, where a timestamped file will be created:
-
-```console
-$ create-index-snapshot -i index --output /var/tmp
-$ ls /var/tmp
-flow-dps-snapshot-03-08-2021-11-33.gz
-```
 
 ### Go Program Restoring the Index
 

--- a/cmd/create-index-snapshot/README.md
+++ b/cmd/create-index-snapshot/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This utility binary creates snapshots of an existing indexes.
+This utility binary creates snapshots of existing indexes.
 When a path to the index (badger database) is specified, the badger API is used to create a backup. 
 This backup is written to the standard output or to a `gzip` archive if the `output` option is specified.
 This backup is compressed with Zstandard compression.

--- a/cmd/create-index-snapshot/README.md
+++ b/cmd/create-index-snapshot/README.md
@@ -2,28 +2,56 @@
 
 ## Description
 
-This utility binary can be used to create a snapshot of an existing index. When a path to the index (badger database) is specified, the badger API is used to create a backup. This backup is compressed with Zstandard compression, encoded to hex and printed on standard output.
+This utility binary can be used to create a snapshot of an existing index.
+When a path to the index (badger database) is specified, the badger API is used to create a backup. 
+This backup is written to standard output or to a `gzip` archive if the `output` option is specified.
+This backup is compressed with Zstandard compression.
 
-This output can be used to restore a database from a previous snapshot.
+Output argument can either be a directory, or a full path to the `.gz` file that will be created.
+If the `output` argument is a directory, a timestamped file will be created (example of a name is `flow-dps-snapshot-03-08-2021-11-02.gz`).
+
+This output can be used to restore a database from a previous snapshot by a `restore-index-snapshot` tool.
 
 ## Usage
 
 ```sh
 Usage of create-index-snapshot:
-  -i, --index string   path to badger database for index (default "index")
-  -l, --level string   log level for JSON logger (default "info")
-  -r, --raw string     target file for raw output (overwrites existing)
+  -i, --index string    database directory for state index (default "index")
+  -l, --level string    log output level (default "info")
+      --output string   output archive for snapshot
+  -r, --raw             use raw binary output instead of hexadecimal when using stdout
 ```
 
-## Example
+## Examples
 
-The program below opens a read-only in-memory badger database and restores the state from the created backup. Error handling is omitted for brevity.
+### Tool Usage
+
+Backup index to a hex-encoded string:
+```console
+$ create-index-snapshot -i index > snapshot.hex
+```
+
+Backup index to a file named `dps-backup.gz` in the `/tmp` directory:
+```console
+$ create-index-snapshot -i index --output /tmp/dps-backup.gz
+```
+
+Backup index to a `/var/tmp` directory, where a timestamped file will be created:
+```console
+$ create-index-snapshot -i index --output /var/tmp
+$ ls /var/tmp
+flow-dps-snapshot-03-08-2021-11-33.gz
+```
+
+### Go Program Restoring the Index
+
+The program below opens a read-only in-memory badger database and restores the state from the created hex-encoded backup. Error handling is omitted for brevity.
 
 ```go
 opts := badger.DefaultOptions("").WithInMemory(true).WithReadOnly(true).WithLogger(nil)
 db, _ := badger.Open(opts)
 
-payload := "output of create-index-snapshot"
+payload := "hex output of create-index-snapshot"
 
 dbSnapshot, _ := zstd.NewReader(hex.NewDecoder(strings.NewReader(payload)))
 defer dbSnapshot.Close()

--- a/cmd/create-index-snapshot/README.md
+++ b/cmd/create-index-snapshot/README.md
@@ -12,10 +12,10 @@ This output can be used to restore a database from a previous snapshot by a `res
 ## Usage
 
 ```sh
-Usage of create-index-snapshot:
-  -f, --format string   output format (hex, gzip or raw) (default "raw")
-  -i, --index string    database directory for state index (default "index")
-  -l, --level string    log output level (default "info")
+Usage of ./create-index-snapshot:
+  -c, --compression string   compression algorithm ("none", "zstd" or "gzip") (default "zstd")
+  -e, --encoding string      output encoding ("none", "hex" or "base64") (default "none")
+  -i, --index string         database directory for state index (default "index")
 ```
 
 ## Examples

--- a/cmd/create-index-snapshot/README.md
+++ b/cmd/create-index-snapshot/README.md
@@ -2,9 +2,9 @@
 
 ## Description
 
-This utility binary can be used to create a snapshot of an existing index.
+This utility binary creates snapshots of an existing indexes.
 When a path to the index (badger database) is specified, the badger API is used to create a backup. 
-This backup is written to standard output or to a `gzip` archive if the `output` option is specified.
+This backup is written to the standard output or to a `gzip` archive if the `output` option is specified.
 This backup is compressed with Zstandard compression.
 
 Output argument can either be a directory, or a full path to the `.gz` file that will be created.
@@ -24,19 +24,22 @@ Usage of create-index-snapshot:
 
 ## Examples
 
-### Tool Usage
+### Usage
 
 Backup index to a hex-encoded string:
+
 ```console
 $ create-index-snapshot -i index > snapshot.hex
 ```
 
 Backup index to a file named `dps-backup.gz` in the `/tmp` directory:
+
 ```console
 $ create-index-snapshot -i index --output /tmp/dps-backup.gz
 ```
 
 Backup index to a `/var/tmp` directory, where a timestamped file will be created:
+
 ```console
 $ create-index-snapshot -i index --output /var/tmp
 $ ls /var/tmp

--- a/cmd/create-index-snapshot/main.go
+++ b/cmd/create-index-snapshot/main.go
@@ -60,8 +60,8 @@ func run() int {
 		flagIndex       string
 	)
 
-	pflag.StringVarP(&flagCompression, "compression", "c", "zstd", "compression algorithm (\"none\", \"zstd\" or \"gzip\")")
-	pflag.StringVarP(&flagEncoding, "encoding", "e", "none", "output encoding (\"none\", \"hex\" or \"base64\")")
+	pflag.StringVarP(&flagCompression, "compression", "c", compressionZstd, "compression algorithm (\"none\", \"zstd\" or \"gzip\")")
+	pflag.StringVarP(&flagEncoding, "encoding", "e", encodingNone, "output encoding (\"none\", \"hex\" or \"base64\")")
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "database directory for state index")
 
 	pflag.Parse()

--- a/cmd/create-index-snapshot/main.go
+++ b/cmd/create-index-snapshot/main.go
@@ -58,25 +58,17 @@ func run() int {
 		flagCompression string
 		flagEncoding    string
 		flagIndex       string
-		flagLevel       string
 	)
 
-	pflag.StringVarP(&flagCompression, "compression", "c", "zstd", "compression algorithm (`none`, `zstd` or `gzip`)")
-	pflag.StringVarP(&flagEncoding, "encoding", "e", "none", "output encoding (`none`, `hex` or `base64`)")
+	pflag.StringVarP(&flagCompression, "compression", "c", "zstd", "compression algorithm (\"none\", \"zstd\" or \"gzip\")")
+	pflag.StringVarP(&flagEncoding, "encoding", "e", "none", "output encoding (\"none\", \"hex\" or \"base64\")")
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "database directory for state index")
-	pflag.StringVarP(&flagLevel, "level", "l", "info", "severity level for logging output")
 
 	pflag.Parse()
 
 	// Initialize the logger.
 	zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
 	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.DebugLevel)
-	level, err := zerolog.ParseLevel(flagLevel)
-	if err != nil {
-		log.Error().Str("level", flagLevel).Err(err).Msg("could not parse log level")
-		return failure
-	}
-	log = log.Level(level)
 
 	// Open the index database.
 	db, err := badger.Open(dps.DefaultOptions(flagIndex).WithReadOnly(true))

--- a/cmd/create-index-snapshot/main.go
+++ b/cmd/create-index-snapshot/main.go
@@ -153,12 +153,10 @@ func getArchivePath(out string) (string, error) {
 	}
 
 	// If not a full path, the output path should be a directory.
-
 	info, err := os.Stat(out)
 	if err != nil {
 		return "", fmt.Errorf("could not stat path: %w", err)
 	}
-
 	if !info.IsDir() {
 		return "", fmt.Errorf("output must be a directory or a full file path")
 	}

--- a/cmd/create-index-snapshot/main.go
+++ b/cmd/create-index-snapshot/main.go
@@ -53,7 +53,7 @@ func run() int {
 
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "database directory for state index")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
-	pflag.StringVarP(&flagFormat, "format", "f", "hex", "output format (hex, gzip or raw)")
+	pflag.StringVarP(&flagFormat, "format", "f", "raw", "output format (hex, gzip or raw)")
 
 	pflag.Parse()
 

--- a/cmd/flow-access-server/main.go
+++ b/cmd/flow-access-server/main.go
@@ -92,12 +92,8 @@ func run() int {
 	}
 	defer db.Close()
 
-	// Initialize storage library.
-	codec, err := zbor.NewCodec()
-	if err != nil {
-		log.Error().Err(err).Msg("could not initialize storage codec")
-		return failure
-	}
+	// Initialize codec.
+	codec := zbor.NewCodec()
 
 	// GRPC API initialization.
 	opts := []logging.Option{

--- a/cmd/flow-access-server/main.go
+++ b/cmd/flow-access-server/main.go
@@ -85,7 +85,7 @@ func run() int {
 	log = log.Level(level)
 
 	// Initialize the index core state and open database in read-only mode.
-	db, err := badger.Open(dps.DefaultOptions(flagIndex).WithReadOnly(true).WithBypassLockGuard(true))
+	db, err := badger.Open(dps.DefaultOptions(flagIndex).WithReadOnly(true))
 	if err != nil {
 		log.Error().Str("index", flagIndex).Err(err).Msg("could not open index DB")
 		return failure

--- a/cmd/flow-dps-client/main.go
+++ b/cmd/flow-dps-client/main.go
@@ -121,12 +121,8 @@ func run() int {
 		args = append(args, arg)
 	}
 
-	// Initialize storage library.
-	codec, err := zbor.NewCodec()
-	if err != nil {
-		log.Error().Err(err).Msg("could not initialize storage codec")
-		return failure
-	}
+	// Initialize codec.
+	codec := zbor.NewCodec()
 
 	// Execute the script using remote lookup and read.
 	client := dps.NewAPIClient(conn)

--- a/cmd/flow-dps-indexer/main.go
+++ b/cmd/flow-dps-indexer/main.go
@@ -155,11 +155,7 @@ func run() int {
 	// interact with a Badger database while encoding and compressing
 	// transparently.
 	var codec dps.Codec
-	codec, err = zbor.NewCodec()
-	if err != nil {
-		log.Error().Err(err).Msg("could not initialize storage codec")
-		return failure
-	}
+	codec = zbor.NewCodec()
 	if flagMetrics {
 		size := rcrowley.NewSize("store")
 		mout.Register(size)

--- a/cmd/flow-dps-server/main.go
+++ b/cmd/flow-dps-server/main.go
@@ -78,7 +78,7 @@ func run() int {
 	log = log.Level(level)
 
 	// Initialize the index core state and open database in read-only mode.
-	db, err := badger.Open(dps.DefaultOptions(flagIndex).WithReadOnly(true).WithBypassLockGuard(true))
+	db, err := badger.Open(dps.DefaultOptions(flagIndex).WithReadOnly(true))
 	if err != nil {
 		log.Error().Str("index", flagIndex).Err(err).Msg("could not open index DB")
 		return failure

--- a/cmd/flow-dps-server/main.go
+++ b/cmd/flow-dps-server/main.go
@@ -86,11 +86,7 @@ func run() int {
 	defer db.Close()
 
 	// Initialize storage library.
-	codec, err := zbor.NewCodec()
-	if err != nil {
-		log.Error().Err(err).Msg("could not initialize storage codec")
-		return failure
-	}
+	codec := zbor.NewCodec()
 	storage := storage.New(codec)
 
 	// GRPC API initialization.

--- a/cmd/flow-rosetta-server/main.go
+++ b/cmd/flow-rosetta-server/main.go
@@ -85,12 +85,8 @@ func run() int {
 	log = log.Level(level)
 	elog := lecho.From(log)
 
-	// Initialize storage library.
-	codec, err := zbor.NewCodec()
-	if err != nil {
-		log.Error().Err(err).Msg("could not initialize storage codec")
-		return failure
-	}
+	// Initialize codec.
+	codec := zbor.NewCodec()
 
 	// Initialize the DPS API client and wrap it for easy usage.
 	conn, err := grpc.Dial(flagAPI, grpc.WithInsecure())

--- a/cmd/restore-index-snapshot/README.md
+++ b/cmd/restore-index-snapshot/README.md
@@ -1,0 +1,48 @@
+# Restore Index Snapshot
+
+## Description
+
+This utility binary can be used to restore index from a previously created snapshot.
+The `input` argument for the utility should point to the `gzip` archive created by the `create-index-snapshot` tool.
+This utility will create a new index, and use the badger API to restore the database.
+Utility will log any metadata written by the backup tool (such as time of backup).
+
+## Usage
+
+```sh
+Usage of ./restore-index-snapshot:
+  -i, --index string   database directory for state index (default "index")
+      --input string   snapshot archive path
+  -l, --level string   log output level (default "info")
+```
+
+## Example
+
+Restore the index to `new_index` from a file `flow-dps-snapshot-03-08-2021-11-02.gz`:
+
+```sh
+restore-index-snapshot -i new_index --input ./flow-dps-snapshot-03-08-2021-11-02.gz 2> >(jq)
+{
+  "level": "info",
+  "file": "./flow-dps-snapshot-03-08-2021-11-02.gz",
+  "time": "2021-08-03T09:45:00Z",
+  "message": "snapshot archive open ok"
+}
+{
+  "level": "info",
+  "comment": "DPS Index snapshot created at 03-08-2021-09-02",
+  "time": "2021-08-03T09:45:00Z",
+  "message": "snapshot archive info"
+}
+{
+  "level": "info",
+  "archive_time": "2021-08-03T11:02:04+02:00",
+  "time": "2021-08-03T09:45:00Z",
+  "message": "snapshot archive creation time"
+}
+{
+  "level": "info",
+  "time": "2021-08-03T09:45:00Z",
+  "message": "snapshot restore complete"
+}
+```

--- a/cmd/restore-index-snapshot/README.md
+++ b/cmd/restore-index-snapshot/README.md
@@ -2,11 +2,13 @@
 
 ## Description
 
-This utility binary restores indexes from previously created snapshots.
-Util reads data from `stdin`, which should be the snapshot data created by the `create-index-snapshot` tool.
-The `format` argument specifies which snapshot format was used - hex, raw or gzip.
-This utility will create a new index, and use the badger API to restore the database.
-It also logs any metadata written by the backup tool (such as the time of backup).
+This utility binary restores snapshots of DPS state index databases.
+It uses the Badger backup API to load a single file snapshot of the database.
+Input is read from the standard input and a file can be piped into the binary if desired.
+The user must indicate which encoding and compression formats were used during snapshot creation.
+
+A new index database will be created at the indicated directory.
+The restoration will fail if an DPS index database already exists at the given path.
 
 ## Usage
 
@@ -19,25 +21,8 @@ Usage of ./restore-index-snapshot:
 
 ## Example
 
-Restore the index to `new_index` from a file `flow-dps-snapshot-03-08-2021-11-02.gz`:
+Restore a DPS index database from a Gzip compressed file without encoding:
 
-```sh
-cat flow-dps-snapshot-03-08-2021-11-02.gz | restore-index-snapshot --format gzip -i new-index 2> >(jq)
-{
-  "level": "info",
-  "comment": "DPS Index snapshot created at 16-08-2021-08-56",
-  "time": "2021-08-16T08:56:48Z",
-  "message": "snapshot archive info"
-}
-{
-  "level": "info",
-  "archive_time": "2021-08-16T10:56:31+02:00",
-  "time": "2021-08-16T08:56:48Z",
-  "message": "snapshot archive creation time"
-}
-{
-  "level": "info",
-  "time": "2021-08-16T08:56:48Z",
-  "message": "snapshot restore complete"
-}
+```console
+$ restore-index-snapshot -i /var/dps/index -c gzip < dps-index-snapshot.gz
 ```

--- a/cmd/restore-index-snapshot/README.md
+++ b/cmd/restore-index-snapshot/README.md
@@ -11,11 +11,11 @@ It also logs any metadata written by the backup tool (such as the time of backup
 ## Usage
 
 ```sh
-Usage of restore-index-snapshot:
-  -f, --format string   input format (hex, gzip or raw) (default "raw")
-  -i, --index string    database directory for state index (default "index")
-  -l, --level string    log output level (default "info")
-  ```
+Usage of ./restore-index-snapshot:
+  -c, --compression string   compression algorithm ("none", "zstd" or "gzip") (default "zstd")
+  -e, --encoding string      output encoding ("none", "hex" or "base64") (default "none")
+  -i, --index string         database directory for state index (default "index")
+```
 
 ## Example
 

--- a/cmd/restore-index-snapshot/README.md
+++ b/cmd/restore-index-snapshot/README.md
@@ -2,10 +2,10 @@
 
 ## Description
 
-This utility binary can be used to restore index from a previously created snapshot.
+This utility binary restores indexes from previously created snapshots.
 The `input` argument for the utility should point to the `gzip` archive created by the `create-index-snapshot` tool.
 This utility will create a new index, and use the badger API to restore the database.
-Utility will log any metadata written by the backup tool (such as time of backup).
+It also logs any metadata written by the backup tool (such as the time of backup).
 
 ## Usage
 

--- a/cmd/restore-index-snapshot/README.md
+++ b/cmd/restore-index-snapshot/README.md
@@ -3,46 +3,41 @@
 ## Description
 
 This utility binary restores indexes from previously created snapshots.
-The `input` argument for the utility should point to the `gzip` archive created by the `create-index-snapshot` tool.
+Util reads data from `stdin`, which should be the snapshot data created by the `create-index-snapshot` tool.
+The `format` argument specifies which snapshot format was used - hex, raw or gzip.
 This utility will create a new index, and use the badger API to restore the database.
 It also logs any metadata written by the backup tool (such as the time of backup).
 
 ## Usage
 
 ```sh
-Usage of ./restore-index-snapshot:
-  -i, --index string   database directory for state index (default "index")
-      --input string   snapshot archive path
-  -l, --level string   log output level (default "info")
-```
+Usage of restore-index-snapshot:
+  -f, --format string   input format (hex, gzip or raw) (default "raw")
+  -i, --index string    database directory for state index (default "index")
+  -l, --level string    log output level (default "info")
+  ```
 
 ## Example
 
 Restore the index to `new_index` from a file `flow-dps-snapshot-03-08-2021-11-02.gz`:
 
 ```sh
-restore-index-snapshot -i new_index --input ./flow-dps-snapshot-03-08-2021-11-02.gz 2> >(jq)
+cat flow-dps-snapshot-03-08-2021-11-02.gz | restore-index-snapshot --format gzip -i new-index 2> >(jq)
 {
   "level": "info",
-  "file": "./flow-dps-snapshot-03-08-2021-11-02.gz",
-  "time": "2021-08-03T09:45:00Z",
-  "message": "snapshot archive open ok"
-}
-{
-  "level": "info",
-  "comment": "DPS Index snapshot created at 03-08-2021-09-02",
-  "time": "2021-08-03T09:45:00Z",
+  "comment": "DPS Index snapshot created at 16-08-2021-08-56",
+  "time": "2021-08-16T08:56:48Z",
   "message": "snapshot archive info"
 }
 {
   "level": "info",
-  "archive_time": "2021-08-03T11:02:04+02:00",
-  "time": "2021-08-03T09:45:00Z",
+  "archive_time": "2021-08-16T10:56:31+02:00",
+  "time": "2021-08-16T08:56:48Z",
   "message": "snapshot archive creation time"
 }
 {
   "level": "info",
-  "time": "2021-08-03T09:45:00Z",
+  "time": "2021-08-16T08:56:48Z",
   "message": "snapshot restore complete"
 }
 ```

--- a/cmd/restore-index-snapshot/main.go
+++ b/cmd/restore-index-snapshot/main.go
@@ -51,7 +51,7 @@ func run() int {
 
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "database directory for state index")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
-	pflag.StringVarP(&flagFormat, "format", "f", "hex", "input format (hex, gzip or raw)")
+	pflag.StringVarP(&flagFormat, "format", "f", "raw", "input format (hex, gzip or raw)")
 
 	pflag.Parse()
 

--- a/cmd/restore-index-snapshot/main.go
+++ b/cmd/restore-index-snapshot/main.go
@@ -1,0 +1,118 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package main
+
+import (
+	"compress/gzip"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/klauspost/compress/zstd"
+	"github.com/rs/zerolog"
+	"github.com/spf13/pflag"
+
+	"github.com/optakt/flow-dps/codec/zbor"
+	"github.com/optakt/flow-dps/models/dps"
+)
+
+const (
+	success = 0
+	failure = 1
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+
+	// Parse the command line arguments.
+	var (
+		flagIndex string
+		flagLevel string
+		flagInput string
+	)
+
+	pflag.StringVarP(&flagIndex, "index", "i", "index", "database directory for state index")
+	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
+	pflag.StringVar(&flagInput, "input", "", "snapshot archive path")
+
+	pflag.Parse()
+
+	// Initialize the logger.
+	zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
+	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.DebugLevel)
+	level, err := zerolog.ParseLevel(flagLevel)
+	if err != nil {
+		log.Error().Str("level", flagLevel).Err(err).Msg("could not parse log level")
+		return failure
+	}
+	log = log.Level(level)
+
+	// Verify the snapshot archive path.
+	if flagInput == "" {
+		log.Error().Msg("snapshot archive path missing")
+		return failure
+	}
+
+	// Open the input gzip file.
+	file, err := os.Open(flagInput)
+	if err != nil {
+		log.Error().Str("file", flagInput).Err(err).Msg("could not open snapshot archive")
+		return failure
+	}
+	defer file.Close()
+
+	// Create a gzip reader.
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		log.Error().Err(err).Msg("could not create gzip reader")
+		return failure
+	}
+
+	log.Info().Str("file", flagInput).Msg("snapshot archive open ok")
+
+	// Log the snapshot metadata.
+	log.Info().Str("comment", reader.Comment).Msg("snapshot archive info")
+	log.Info().Time("archive_time", reader.ModTime).Msg("snapshot archive creation time")
+
+	// Create a decompressor with the default dictionary.
+	decompressor, err := zstd.NewReader(reader, zstd.WithDecoderDicts(zbor.Dictionary))
+	if err != nil {
+		log.Error().Err(err).Msg("could not create decompressor")
+		return failure
+	}
+
+	// Open the index database.
+	db, err := badger.Open(dps.DefaultOptions(flagIndex))
+	if err != nil {
+		log.Error().Str("index", flagIndex).Err(err).Msg("could not open badger db")
+		return failure
+	}
+	defer db.Close()
+
+	// Restore the database
+	err = db.Load(decompressor, runtime.GOMAXPROCS(0))
+	if err != nil {
+		log.Error().Err(err).Msg("could not restore database")
+		return failure
+	}
+
+	log.Info().Msg("snapshot restore complete")
+
+	return success
+}

--- a/cmd/restore-index-snapshot/main.go
+++ b/cmd/restore-index-snapshot/main.go
@@ -28,7 +28,10 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 
+	"github.com/optakt/flow-dps/codec/zbor"
 	"github.com/optakt/flow-dps/models/dps"
+	"github.com/optakt/flow-dps/service/index"
+	"github.com/optakt/flow-dps/service/storage"
 )
 
 const (
@@ -78,6 +81,14 @@ func run() int {
 		return failure
 	}
 	defer db.Close()
+
+	// Check if the database is empty.
+	index := index.NewReader(db, storage.New(zbor.NewCodec()))
+	_, err = index.First()
+	if err == nil {
+		log.Error().Msg("database directory already contains index database")
+		return failure
+	}
 
 	// We will consume from stdin; if the user wants to load from a file, he can
 	// pipe it into the command.

--- a/cmd/restore-index-snapshot/main.go
+++ b/cmd/restore-index-snapshot/main.go
@@ -64,8 +64,8 @@ func run() int {
 		flagIndex       string
 	)
 
-	pflag.StringVarP(&flagCompression, "compression", "c", "zstd", "compression algorithm (\"none\", \"zstd\" or \"gzip\")")
-	pflag.StringVarP(&flagEncoding, "encoding", "e", "none", "output encoding (\"none\", \"hex\" or \"base64\")")
+	pflag.StringVarP(&flagCompression, "compression", "c", compressionZstd, "compression algorithm (\"none\", \"zstd\" or \"gzip\")")
+	pflag.StringVarP(&flagEncoding, "encoding", "e", encodingNone, "output encoding (\"none\", \"hex\" or \"base64\")")
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "database directory for state index")
 
 	pflag.Parse()

--- a/cmd/restore-index-snapshot/main.go
+++ b/cmd/restore-index-snapshot/main.go
@@ -59,28 +59,20 @@ func run() int {
 		flagCompression string
 		flagEncoding    string
 		flagIndex       string
-		flagLevel       string
 	)
 
-	pflag.StringVarP(&flagCompression, "compression", "c", "zstd", "compression algorithm (`none`, `zstd` or `gzip`)")
-	pflag.StringVarP(&flagEncoding, "encoding", "e", "none", "output encoding (`none`, `hex` or `base64`)")
+	pflag.StringVarP(&flagCompression, "compression", "c", "zstd", "compression algorithm (\"none\", \"zstd\" or \"gzip\")")
+	pflag.StringVarP(&flagEncoding, "encoding", "e", "none", "output encoding (\"none\", \"hex\" or \"base64\")")
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "database directory for state index")
-	pflag.StringVarP(&flagLevel, "level", "l", "info", "severity level for logging output")
 
 	pflag.Parse()
 
 	// Initialize the logger.
 	zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
 	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.DebugLevel)
-	level, err := zerolog.ParseLevel(flagLevel)
-	if err != nil {
-		log.Error().Str("level", flagLevel).Err(err).Msg("could not parse log level")
-		return failure
-	}
-	log = log.Level(level)
 
 	// Open the index database.
-	db, err := badger.Open(dps.DefaultOptions(flagIndex).WithReadOnly(true))
+	db, err := badger.Open(dps.DefaultOptions(flagIndex))
 	if err != nil {
 		log.Error().Str("index", flagIndex).Err(err).Msg("could not open badger db")
 		return failure

--- a/codec/zbor/codec.go
+++ b/codec/zbor/codec.go
@@ -28,28 +28,28 @@ type Codec struct {
 }
 
 // NewCodec creates a new Codec.
-func NewCodec() (*Codec, error) {
+func NewCodec() *Codec {
 
+	// We should never fail here if the options are valid, so use panic to keep
+	// the function signature for the codec clean.
 	options := cbor.CanonicalEncOptions()
 	options.Time = cbor.TimeRFC3339Nano
 	encoder, err := options.EncMode()
 	if err != nil {
-		return nil, fmt.Errorf("could not initialize encoder: %w", err)
+		panic(err)
 	}
-
 	compressor, err := zstd.NewWriter(nil,
 		zstd.WithEncoderLevel(zstd.SpeedDefault),
 		zstd.WithEncoderDict(Dictionary),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("could not initialize compressor: %w", err)
+		panic(err)
 	}
-
 	decompressor, err := zstd.NewReader(nil,
 		zstd.WithDecoderDicts(Dictionary),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("could not initialize decompressor: %w", err)
+		panic(err)
 	}
 
 	c := Codec{
@@ -58,7 +58,7 @@ func NewCodec() (*Codec, error) {
 		decompressor: decompressor,
 	}
 
-	return &c, nil
+	return &c
 }
 
 func (c *Codec) Encode(value interface{}) ([]byte, error) {

--- a/service/index/index_integration_test.go
+++ b/service/index/index_integration_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
 
@@ -320,8 +319,7 @@ func TestIndex(t *testing.T) {
 func setupIndex(t *testing.T) (*index.Reader, *index.Writer) {
 	t.Helper()
 
-	codec, err := zbor.NewCodec()
-	require.NoError(t, err)
+	codec := zbor.NewCodec()
 
 	db := helpers.InMemoryDB(t)
 	lib := storage.New(codec)

--- a/service/storage/auxiliary_test.go
+++ b/service/storage/auxiliary_test.go
@@ -305,8 +305,7 @@ func insertKeyValue(t *testing.T, db *badger.DB, key []byte, value uint64) error
 	t.Helper()
 
 	err := db.Update(func(txn *badger.Txn) error {
-		enc, err := zbor.NewCodec()
-		require.NoError(t, err)
+		enc := zbor.NewCodec()
 
 		val, err := enc.Marshal(value)
 		require.NoError(t, err)

--- a/service/storage/operations_integration_test.go
+++ b/service/storage/operations_integration_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
@@ -341,8 +340,7 @@ func TestLibrary(t *testing.T) {
 func setupLibrary(t *testing.T) (*badger.DB, *storage.Library) {
 	t.Helper()
 
-	codec, err := zbor.NewCodec()
-	require.NoError(t, err)
+	codec := zbor.NewCodec()
 
 	return helpers.InMemoryDB(t), storage.New(codec)
 }


### PR DESCRIPTION
## Goal of this PR

Fixes #315.

This PR introduces the following functionalities:
- `create-index-snapshot` can backup to a gzip archive
- `restore-index-snapshot` can restore snapshot from a gzip archive

I used `gzip` archive instead of `tar.gz` as originally discussed. The reason is that the `tar` header requires that the size of the file is known in advance, which we do not know. We could compress the index in chunks though, so it is still an option, I just was not sure how big of a preference that is.

To test this, I also wrote a `snapshot-hash` tool, that returns the checksum of all DPS-relevant data in an index (on master that were headers, commits, transactions, events, payloads). With that, I could check that the checksum of the original and restored index match.

However, with the prototype, it assumed the index had everything, while in reality we might backup and restore an index that has only headers and payloads (the tool would return an error on failing to retrieve something). It can definitely be improved, just wasn't sure if I should be spending the time on that if it's not going to be used.

We could also create a single tool, something like `dps-snapshot-manager` or just `dps-index-snapshot` that handles everything - backup, restore and checksum.

What do you think?

[Source code](https://gist.github.com/Maelkum/e932ba8f16ea331e8ffdee869a04853d) for the checksum tool.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date