### PR TITLE
Fix rosetta operation indices

### DIFF
--- a/rosetta/converter/converter.go
+++ b/rosetta/converter/converter.go
@@ -53,7 +53,7 @@ func New(gen Generator) (*Converter, error) {
 	return &c, nil
 }
 
-func (c *Converter) EventToOperation(event flow.Event) (operation *object.Operation, err error) {
+func (c *Converter) EventToOperation(index uint, event flow.Event) (operation *object.Operation, err error) {
 
 	// Decode the event payload into a Cadence value and cast it to a Cadence event.
 	value, err := json.Decode(event.Payload)
@@ -91,7 +91,8 @@ func (c *Converter) EventToOperation(event flow.Event) (operation *object.Operat
 
 	op := object.Operation{
 		ID: identifier.Operation{
-			Index: uint(event.EventIndex),
+			Index:        index,
+			NetworkIndex: uint(event.EventIndex),
 		},
 		Status: dps.StatusCompleted,
 		AccountID: identifier.Account{

--- a/rosetta/converter/converter_test.go
+++ b/rosetta/converter/converter_test.go
@@ -124,7 +124,8 @@ func TestConverter_EventToOperation(t *testing.T) {
 
 	testDepositOp := object.Operation{
 		ID: identifier.Operation{
-			Index: 0,
+			Index:        1,
+			NetworkIndex: 10,
 		},
 		Type:   dps.OperationTransfer,
 		Status: dps.StatusCompleted,
@@ -141,7 +142,8 @@ func TestConverter_EventToOperation(t *testing.T) {
 	}
 	testWithdrawalOp := object.Operation{
 		ID: identifier.Operation{
-			Index: 1,
+			Index:        2,
+			NetworkIndex: 20,
 		},
 		Type:   dps.OperationTransfer,
 		Status: dps.StatusCompleted,
@@ -234,6 +236,7 @@ func TestConverter_EventToOperation(t *testing.T) {
 	tests := []struct {
 		name string
 
+		index uint
 		event flow.Event
 
 		wantOperation  *object.Operation
@@ -243,11 +246,12 @@ func TestConverter_EventToOperation(t *testing.T) {
 		{
 			name: "nominal case with deposit event",
 
+			index: 1,
 			event: flow.Event{
 				TransactionID: id,
 				Type:          mocks.GenericEventType(0),
 				Payload:       depositEventPayload,
-				EventIndex:    0,
+				EventIndex:    10,
 			},
 
 			wantErr:        assert.NoError,
@@ -257,11 +261,12 @@ func TestConverter_EventToOperation(t *testing.T) {
 		{
 			name: "nominal case with withdrawal event",
 
+			index: 2,
 			event: flow.Event{
 				TransactionID: id,
 				Type:          mocks.GenericEventType(1),
 				Payload:       withdrawalEventPayload,
-				EventIndex:    1,
+				EventIndex:    20,
 			},
 
 			wantErr:        assert.NoError,
@@ -326,7 +331,7 @@ func TestConverter_EventToOperation(t *testing.T) {
 				withdrawal: mocks.GenericEventType(1),
 			}
 
-			got, err := cvt.EventToOperation(test.event)
+			got, err := cvt.EventToOperation(test.index, test.event)
 
 			test.wantErr(t, err)
 			test.wantIrrelevant(t, errors.Is(err, ErrIrrelevant))

--- a/rosetta/failure/description.go
+++ b/rosetta/failure/description.go
@@ -16,6 +16,7 @@ package failure
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -77,14 +78,14 @@ func WithErr(err error) FieldFunc {
 
 func WithInt(key string, val int) FieldFunc {
 	return func(f *Fields) {
-		field := Field{Key: key, Val: val}
+		field := Field{Key: key, Val: strconv.FormatInt(int64(val), 10)}
 		*f = append(*f, field)
 	}
 }
 
 func WithUint64(key string, val uint64) FieldFunc {
 	return func(f *Fields) {
-		field := Field{Key: key, Val: val}
+		field := Field{Key: key, Val: strconv.FormatUint(val, 10)}
 		*f = append(*f, field)
 	}
 }

--- a/rosetta/failure/description.go
+++ b/rosetta/failure/description.go
@@ -17,6 +17,8 @@ package failure
 import (
 	"fmt"
 	"strings"
+
+	"github.com/onflow/flow-go/model/flow"
 )
 
 type Description struct {
@@ -81,6 +83,13 @@ func WithInt(key string, val int) FieldFunc {
 }
 
 func WithUint64(key string, val uint64) FieldFunc {
+	return func(f *Fields) {
+		field := Field{Key: key, Val: val}
+		*f = append(*f, field)
+	}
+}
+
+func WithID(key string, val flow.Identifier) FieldFunc {
 	return func(f *Fields) {
 		field := Field{Key: key, Val: val}
 		*f = append(*f, field)

--- a/rosetta/identifier/operation.go
+++ b/rosetta/identifier/operation.go
@@ -17,5 +17,6 @@ package identifier
 // Operation uniquely identifies an operation within a transaction. No network index is
 // needed because of the absence Flow does not support sharding.
 type Operation struct {
-	Index uint `json:"index"`
+	Index        uint `json:"index"`
+	NetworkIndex uint `json:"network_index"`
 }

--- a/rosetta/object/transaction.go
+++ b/rosetta/object/transaction.go
@@ -25,5 +25,5 @@ import (
 // "lockTime".
 type Transaction struct {
 	ID         identifier.Transaction `json:"transaction_identifier"`
-	Operations []Operation            `json:"operations"`
+	Operations []*Operation           `json:"operations"`
 }

--- a/rosetta/retriever/convert.go
+++ b/rosetta/retriever/convert.go
@@ -12,24 +12,30 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package validator
+package retriever
 
 import (
 	"github.com/onflow/flow-go/model/flow"
 
-	"github.com/optakt/flow-dps/rosetta/failure"
 	"github.com/optakt/flow-dps/rosetta/identifier"
 )
 
-func (v *Validator) Transaction(transaction identifier.Transaction) (flow.Identifier, error) {
-
-	txID, err := flow.HexStringToIdentifier(transaction.Hash)
-	if err != nil {
-		return flow.ZeroID, failure.InvalidTransaction{
-			Hash:        transaction.Hash,
-			Description: failure.NewDescription("transaction hash is not a valid hex-encoded string"),
-		}
+func rosettaTxID(txID flow.Identifier) identifier.Transaction {
+	return identifier.Transaction{
+		Hash: txID.String(),
 	}
+}
 
-	return txID, nil
+func rosettaBlockID(height uint64, blockID flow.Identifier) identifier.Block {
+	return identifier.Block{
+		Index: &height,
+		Hash:  blockID.String(),
+	}
+}
+
+func rosettaCurrency(symbol string, decimals uint) identifier.Currency {
+	return identifier.Currency{
+		Symbol:   symbol,
+		Decimals: decimals,
+	}
 }

--- a/rosetta/retriever/converter.go
+++ b/rosetta/retriever/converter.go
@@ -21,5 +21,5 @@ import (
 )
 
 type Converter interface {
-	EventToOperation(event flow.Event) (transaction *object.Operation, err error)
+	EventToOperation(index uint, event flow.Event) (transaction *object.Operation, err error)
 }

--- a/rosetta/retriever/converter.go
+++ b/rosetta/retriever/converter.go
@@ -21,5 +21,5 @@ import (
 )
 
 type Converter interface {
-	EventToOperation(index uint, event flow.Event) (transaction *object.Operation, err error)
+	EventToOperation(index uint, event flow.Event) (operation *object.Operation, err error)
 }

--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -198,7 +198,7 @@ func (r *Retriever) Block(rosBlockID identifier.Block) (*object.Block, []identif
 	var blockTransactions []*object.Transaction
 	var extraTransactions []identifier.Transaction
 	for index, txID := range txIDs {
-		if index > int(r.cfg.TransactionLimit) {
+		if index >= int(r.cfg.TransactionLimit) {
 			extraTransactions = append(extraTransactions, identifier.Transaction{Hash: txID.String()})
 			continue
 		}

--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -207,7 +207,7 @@ func (r *Retriever) Block(rosBlockID identifier.Block) (*object.Block, []identif
 			return nil, nil, fmt.Errorf("could not get operations: %w", err)
 		}
 		rosTx := object.Transaction{
-			ID:         identifier.Transaction{Hash: txID.String()},
+			ID:         rosettaTxID(txID),
 			Operations: ops,
 		}
 		blockTransactions = append(blockTransactions, &rosTx)
@@ -218,11 +218,11 @@ func (r *Retriever) Block(rosBlockID identifier.Block) (*object.Block, []identif
 	// See https://www.rosetta-api.org/docs/common_mistakes.html#malformed-genesis-block
 	// We thus initialize the parent as the current block, and if the header is
 	// not the root block, we use it's actual parent.
-	var parent identifier.Block
 	first, err := r.index.First()
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get first block index: %w", err)
 	}
+	var parent identifier.Block
 	if header.Height == first {
 		parent = rosettaBlockID(height, blockID)
 	} else {
@@ -292,7 +292,7 @@ func (r *Retriever) Transaction(rosBlockID identifier.Block, rosTxID identifier.
 		return nil, fmt.Errorf("could not get events: %w", err)
 	}
 
-	// Convert events to operations and group them by transaction ID.
+	// Convert events to operations.
 	ops, err := r.operations(txID, events)
 	if err != nil {
 		return nil, fmt.Errorf("could not convert events to operations: %w", err)

--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -120,7 +120,7 @@ func (r *Retriever) Balances(rosBlockID identifier.Block, rosAccountID identifie
 
 	// Run validation on the currency qualifiers. This checks basically if we know the
 	// currency and if it has the correct decimals set, if they are set.
-	symbols := make([]string, len(rosCurrencies))
+	symbols := make([]string, 0, len(rosCurrencies))
 	decimals := make(map[string]uint, len(rosCurrencies))
 	for _, currency := range rosCurrencies {
 		symbol, decimal, err := r.validate.Currency(currency)

--- a/rosetta/retriever/retriever_test.go
+++ b/rosetta/retriever/retriever_test.go
@@ -179,17 +179,17 @@ func TestRetriever_Balances(t *testing.T) {
 		t.Parallel()
 
 		validator := mocks.BaselineValidator(t)
-		validator.AccountFunc = func(address identifier.Account) error {
+		validator.AccountFunc = func(address identifier.Account) (flow.Address, error) {
 			assert.Equal(t, mocks.GenericAccountID(0), address)
-			return nil
+			return mocks.GenericAccount.Address, nil
 		}
-		validator.BlockFunc = func(rosBlockID identifier.Block) (identifier.Block, error) {
+		validator.BlockFunc = func(rosBlockID identifier.Block) (uint64, flow.Identifier, error) {
 			assert.Equal(t, mocks.GenericBlockQualifier, rosBlockID)
-			return rosBlockID, nil
+			return mocks.GenericHeader.Height, mocks.GenericHeader.ID(), nil
 		}
-		validator.CurrencyFunc = func(currency identifier.Currency) (identifier.Currency, error) {
+		validator.CurrencyFunc = func(currency identifier.Currency) (string, uint, error) {
 			assert.Equal(t, mocks.GenericCurrency, currency)
-			return currency, nil
+			return mocks.GenericCurrency.Symbol, mocks.GenericCurrency.Decimals, nil
 		}
 
 		generator := mocks.BaselineGenerator(t)
@@ -235,9 +235,9 @@ func TestRetriever_Balances(t *testing.T) {
 		t.Parallel()
 
 		validator := mocks.BaselineValidator(t)
-		validator.BlockFunc = func(rosBlockID identifier.Block) (identifier.Block, error) {
+		validator.BlockFunc = func(rosBlockID identifier.Block) (uint64, flow.Identifier, error) {
 			assert.Equal(t, mocks.GenericBlockQualifier, rosBlockID)
-			return identifier.Block{}, mocks.GenericError
+			return 0, flow.ZeroID, mocks.GenericError
 		}
 
 		ret, err := baselineRetriever(t)
@@ -257,8 +257,8 @@ func TestRetriever_Balances(t *testing.T) {
 		t.Parallel()
 
 		validator := mocks.BaselineValidator(t)
-		validator.AccountFunc = func(address identifier.Account) error {
-			return mocks.GenericError
+		validator.AccountFunc = func(account identifier.Account) (flow.Address, error) {
+			return flow.EmptyAddress, mocks.GenericError
 		}
 
 		ret, err := baselineRetriever(t)
@@ -278,8 +278,8 @@ func TestRetriever_Balances(t *testing.T) {
 		t.Parallel()
 
 		validator := mocks.BaselineValidator(t)
-		validator.CurrencyFunc = func(currency identifier.Currency) (identifier.Currency, error) {
-			return currency, mocks.GenericError
+		validator.CurrencyFunc = func(currency identifier.Currency) (string, uint, error) {
+			return "", 0, mocks.GenericError
 		}
 
 		ret, err := baselineRetriever(t)
@@ -357,9 +357,9 @@ func TestRetriever_Block(t *testing.T) {
 		}
 
 		validator := mocks.BaselineValidator(t)
-		validator.BlockFunc = func(rosBlockID identifier.Block) (identifier.Block, error) {
+		validator.BlockFunc = func(rosBlockID identifier.Block) (uint64, flow.Identifier, error) {
 			assert.Equal(t, mocks.GenericBlockQualifier, rosBlockID)
-			return rosBlockID, nil
+			return mocks.GenericHeader.Height, mocks.GenericHeader.ID(), nil
 		}
 
 		generator := mocks.BaselineGenerator(t)
@@ -373,7 +373,7 @@ func TestRetriever_Block(t *testing.T) {
 		}
 
 		convert := mocks.BaselineConverter(t)
-		convert.EventToOperationFunc = func(event flow.Event) (*object.Operation, error) {
+		convert.EventToOperationFunc = func(index uint, event flow.Event) (*object.Operation, error) {
 			assert.Contains(t, mocks.GenericEvents(4), event)
 
 			var op object.Operation
@@ -424,9 +424,9 @@ func TestRetriever_Block(t *testing.T) {
 		}
 
 		validator := mocks.BaselineValidator(t)
-		validator.BlockFunc = func(rosBlockID identifier.Block) (identifier.Block, error) {
+		validator.BlockFunc = func(rosBlockID identifier.Block) (uint64, flow.Identifier, error) {
 			assert.Equal(t, mocks.GenericBlockQualifier, rosBlockID)
-			return rosBlockID, nil
+			return mocks.GenericHeader.Height, mocks.GenericHeader.ID(), nil
 		}
 
 		generator := mocks.BaselineGenerator(t)
@@ -440,7 +440,7 @@ func TestRetriever_Block(t *testing.T) {
 		}
 
 		convert := mocks.BaselineConverter(t)
-		convert.EventToOperationFunc = func(event flow.Event) (*object.Operation, error) {
+		convert.EventToOperationFunc = func(index uint, event flow.Event) (*object.Operation, error) {
 			assert.Contains(t, mocks.GenericEvents(4), event)
 
 			var op object.Operation
@@ -491,9 +491,9 @@ func TestRetriever_Block(t *testing.T) {
 			return mocks.GenericEvents(4), nil
 		}
 		validator := mocks.BaselineValidator(t)
-		validator.BlockFunc = func(rosBlockID identifier.Block) (identifier.Block, error) {
+		validator.BlockFunc = func(rosBlockID identifier.Block) (uint64, flow.Identifier, error) {
 			assert.Equal(t, mocks.GenericBlockQualifier, rosBlockID)
-			return rosBlockID, nil
+			return mocks.GenericHeader.Height, mocks.GenericHeader.ID(), nil
 		}
 		generator := mocks.BaselineGenerator(t)
 		generator.TokensDepositedFunc = func(symbol string) (string, error) {
@@ -505,7 +505,7 @@ func TestRetriever_Block(t *testing.T) {
 			return string(mocks.GenericEventType(1)), nil
 		}
 		convert := mocks.BaselineConverter(t)
-		convert.EventToOperationFunc = func(event flow.Event) (*object.Operation, error) {
+		convert.EventToOperationFunc = func(index uint, event flow.Event) (*object.Operation, error) {
 			assert.Contains(t, mocks.GenericEvents(4), event)
 
 			var op object.Operation
@@ -582,8 +582,8 @@ func TestRetriever_Block(t *testing.T) {
 		t.Parallel()
 
 		validator := mocks.BaselineValidator(t)
-		validator.BlockFunc = func(identifier.Block) (identifier.Block, error) {
-			return identifier.Block{}, mocks.GenericError
+		validator.BlockFunc = func(identifier.Block) (uint64, flow.Identifier, error) {
+			return 0, flow.ZeroID, mocks.GenericError
 		}
 
 		ret, err := baselineRetriever(t)
@@ -672,7 +672,7 @@ func TestRetriever_Block(t *testing.T) {
 		t.Parallel()
 
 		convert := mocks.BaselineConverter(t)
-		convert.EventToOperationFunc = func(event flow.Event) (*object.Operation, error) {
+		convert.EventToOperationFunc = func(index uint, event flow.Event) (*object.Operation, error) {
 			return nil, mocks.GenericError
 		}
 
@@ -691,13 +691,13 @@ func TestRetriever_Transaction(t *testing.T) {
 		t.Parallel()
 
 		validator := mocks.BaselineValidator(t)
-		validator.BlockFunc = func(rosBlockID identifier.Block) (identifier.Block, error) {
+		validator.BlockFunc = func(rosBlockID identifier.Block) (uint64, flow.Identifier, error) {
 			assert.Equal(t, mocks.GenericBlockQualifier, rosBlockID)
-			return rosBlockID, nil
+			return mocks.GenericHeader.Height, mocks.GenericHeader.ID(), nil
 		}
-		validator.TransactionFunc = func(transaction identifier.Transaction) error {
+		validator.TransactionFunc = func(transaction identifier.Transaction) (flow.Identifier, error) {
 			assert.Equal(t, mocks.GenericTransactionQualifier(0), transaction)
-			return nil
+			return mocks.GenericTransaction(0).ID(), nil
 		}
 
 		generator := mocks.BaselineGenerator(t)
@@ -726,7 +726,7 @@ func TestRetriever_Transaction(t *testing.T) {
 		}
 
 		convert := mocks.BaselineConverter(t)
-		convert.EventToOperationFunc = func(event flow.Event) (*object.Operation, error) {
+		convert.EventToOperationFunc = func(index uint, event flow.Event) (*object.Operation, error) {
 			assert.Contains(t, mocks.GenericEvents(4), event)
 
 			var op object.Operation
@@ -786,8 +786,8 @@ func TestRetriever_Transaction(t *testing.T) {
 		t.Parallel()
 
 		validator := mocks.BaselineValidator(t)
-		validator.BlockFunc = func(identifier.Block) (identifier.Block, error) {
-			return identifier.Block{}, mocks.GenericError
+		validator.BlockFunc = func(identifier.Block) (uint64, flow.Identifier, error) {
+			return 0, flow.ZeroID, mocks.GenericError
 		}
 
 		ret, err := baselineRetriever(t)
@@ -803,8 +803,8 @@ func TestRetriever_Transaction(t *testing.T) {
 		t.Parallel()
 
 		validator := mocks.BaselineValidator(t)
-		validator.TransactionFunc = func(transaction identifier.Transaction) error {
-			return mocks.GenericError
+		validator.TransactionFunc = func(transaction identifier.Transaction) (flow.Identifier, error) {
+			return flow.ZeroID, mocks.GenericError
 		}
 
 		ret, err := baselineRetriever(t)
@@ -903,7 +903,7 @@ func TestRetriever_Transaction(t *testing.T) {
 		t.Parallel()
 
 		convert := mocks.BaselineConverter(t)
-		convert.EventToOperationFunc = func(event flow.Event) (*object.Operation, error) {
+		convert.EventToOperationFunc = func(index uint, event flow.Event) (*object.Operation, error) {
 			return nil, mocks.GenericError
 		}
 
@@ -927,7 +927,7 @@ func baselineRetriever(t *testing.T) (*Retriever, error) {
 	invoker := mocks.BaselineInvoker(t)
 
 	convert := mocks.BaselineConverter(t)
-	convert.EventToOperationFunc = func(event flow.Event) (*object.Operation, error) {
+	convert.EventToOperationFunc = func(index uint, event flow.Event) (*object.Operation, error) {
 		var op object.Operation
 		switch event.Type {
 		case mocks.GenericEventType(0):
@@ -951,8 +951,4 @@ func baselineRetriever(t *testing.T) (*Retriever, error) {
 	}
 
 	return &retriever, nil
-}
-
-func getUint64P(n uint64) *uint64 {
-	return &n
 }

--- a/rosetta/retriever/validator.go
+++ b/rosetta/retriever/validator.go
@@ -15,12 +15,13 @@
 package retriever
 
 import (
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/optakt/flow-dps/rosetta/identifier"
 )
 
 type Validator interface {
-	Account(rosAccountID identifier.Account) error
-	Block(rosBlockID identifier.Block) (identifier.Block, error)
-	Transaction(rosTxID identifier.Transaction) error
-	Currency(rosCurrency identifier.Currency) (identifier.Currency, error)
+	Account(rosAccountID identifier.Account) (address flow.Address, err error)
+	Block(rosBlockID identifier.Block) (height uint64, blockID flow.Identifier, err error)
+	Transaction(rosTxID identifier.Transaction) (txID flow.Identifier, err error)
+	Currency(rosCurrency identifier.Currency) (symbol string, decimals uint, err error)
 }

--- a/rosetta/validator/account.go
+++ b/rosetta/validator/account.go
@@ -23,13 +23,13 @@ import (
 	"github.com/optakt/flow-dps/rosetta/identifier"
 )
 
-func (v *Validator) Account(account identifier.Account) error {
+func (v *Validator) Account(account identifier.Account) (flow.Address, error) {
 
 	// Parse the address; the length was already validated, but it's still
 	// possible that the characters are not valid hex encoding.
 	bytes, err := hex.DecodeString(account.Address)
 	if err != nil {
-		return failure.InvalidAccount{
+		return flow.EmptyAddress, failure.InvalidAccount{
 			Address:     account.Address,
 			Description: failure.NewDescription("account address is not a valid hex-encoded string"),
 		}
@@ -41,7 +41,7 @@ func (v *Validator) Account(account identifier.Account) error {
 	copy(address[:], bytes)
 	ok := v.params.ChainID.Chain().IsValid(address)
 	if !ok {
-		return failure.InvalidAccount{
+		return flow.EmptyAddress, failure.InvalidAccount{
 			Address: account.Address,
 			Description: failure.NewDescription("account address is not valid for configured chain",
 				failure.WithString("active_chain", v.params.ChainID.String()),
@@ -49,5 +49,5 @@ func (v *Validator) Account(account identifier.Account) error {
 		}
 	}
 
-	return nil
+	return address, nil
 }

--- a/rosetta/validator/currency.go
+++ b/rosetta/validator/currency.go
@@ -20,13 +20,13 @@ import (
 	"github.com/optakt/flow-dps/rosetta/identifier"
 )
 
-func (v *Validator) Currency(currency identifier.Currency) (identifier.Currency, error) {
+func (v *Validator) Currency(currency identifier.Currency) (string, uint, error) {
 
 	// We already checked the token symbol is given, so this merely checks if
 	// the token has been configured yet.
 	_, ok := v.params.Tokens[currency.Symbol]
 	if !ok {
-		return identifier.Currency{}, failure.UnknownCurrency{
+		return "", 0, failure.UnknownCurrency{
 			Symbol:   currency.Symbol,
 			Decimals: currency.Decimals,
 			Description: failure.NewDescription("currency symbol is unknown",
@@ -38,7 +38,7 @@ func (v *Validator) Currency(currency identifier.Currency) (identifier.Currency,
 	// If the token is known, there should always be 8 decimals, as we always use
 	// `UFix64` for tokens on Flow.
 	if currency.Decimals != 0 && currency.Decimals != dps.FlowDecimals {
-		return identifier.Currency{}, failure.InvalidCurrency{
+		return "", 0, failure.InvalidCurrency{
 			Symbol:   currency.Symbol,
 			Decimals: currency.Decimals,
 			Description: failure.NewDescription("currency decimals mismatch with authoritative decimals for symbol",
@@ -47,8 +47,5 @@ func (v *Validator) Currency(currency identifier.Currency) (identifier.Currency,
 		}
 	}
 
-	// At this point decimals are either 8 or empty, so set it.
-	currency.Decimals = 8
-
-	return currency, nil
+	return currency.Symbol, dps.FlowDecimals, nil
 }

--- a/testing/mocks/converter.go
+++ b/testing/mocks/converter.go
@@ -23,14 +23,14 @@ import (
 )
 
 type Converter struct {
-	EventToOperationFunc func(flow.Event) (*object.Operation, error)
+	EventToOperationFunc func(index uint, event flow.Event) (*object.Operation, error)
 }
 
 func BaselineConverter(t *testing.T) *Converter {
 	t.Helper()
 
 	c := Converter{
-		EventToOperationFunc: func(event flow.Event) (*object.Operation, error) {
+		EventToOperationFunc: func(index uint, event flow.Event) (*object.Operation, error) {
 			op := GenericOperation(0)
 			return &op, nil
 		},
@@ -39,6 +39,6 @@ func BaselineConverter(t *testing.T) *Converter {
 	return &c
 }
 
-func (c *Converter) EventToOperation(event flow.Event) (transaction *object.Operation, err error) {
-	return c.EventToOperationFunc(event)
+func (c *Converter) EventToOperation(index uint, event flow.Event) (transaction *object.Operation, err error) {
+	return c.EventToOperationFunc(index, event)
 }

--- a/testing/mocks/validator.go
+++ b/testing/mocks/validator.go
@@ -40,7 +40,7 @@ func BaselineValidator(t *testing.T) *Validator {
 			return GenericHeader.Height, GenericHeader.ID(), nil
 		},
 		TransactionFunc: func(rosTxID identifier.Transaction) (flow.Identifier, error) {
-			return GenericTransaction(0).ID(), nil
+			return GenericIdentifier(0), nil
 		},
 		CurrencyFunc: func(rosCurrency identifier.Currency) (string, uint, error) {
 			return GenericCurrency.Symbol, GenericCurrency.Decimals, nil

--- a/testing/mocks/validator.go
+++ b/testing/mocks/validator.go
@@ -17,49 +17,51 @@ package mocks
 import (
 	"testing"
 
+	"github.com/onflow/flow-go/model/flow"
+
 	"github.com/optakt/flow-dps/rosetta/identifier"
 )
 
 type Validator struct {
-	AccountFunc     func(rosAccountID identifier.Account) error
-	BlockFunc       func(rosBlockID identifier.Block) (identifier.Block, error)
-	TransactionFunc func(rosTxID identifier.Transaction) error
-	CurrencyFunc    func(rosCurrencies identifier.Currency) (identifier.Currency, error)
+	AccountFunc     func(rosAccountID identifier.Account) (flow.Address, error)
+	BlockFunc       func(rosBlockID identifier.Block) (uint64, flow.Identifier, error)
+	TransactionFunc func(rosTxID identifier.Transaction) (flow.Identifier, error)
+	CurrencyFunc    func(rosCurrencies identifier.Currency) (string, uint, error)
 }
 
 func BaselineValidator(t *testing.T) *Validator {
 	t.Helper()
 
 	v := Validator{
-		AccountFunc: func(rosAccountID identifier.Account) error {
-			return nil
+		AccountFunc: func(rosAccountID identifier.Account) (flow.Address, error) {
+			return GenericAddress(0), nil
 		},
-		BlockFunc: func(rosBlockID identifier.Block) (identifier.Block, error) {
-			return GenericBlockQualifier, nil
+		BlockFunc: func(rosBlockID identifier.Block) (uint64, flow.Identifier, error) {
+			return GenericHeader.Height, GenericHeader.ID(), nil
 		},
-		TransactionFunc: func(rosTxID identifier.Transaction) error {
-			return nil
+		TransactionFunc: func(rosTxID identifier.Transaction) (flow.Identifier, error) {
+			return GenericTransaction(0).ID(), nil
 		},
-		CurrencyFunc: func(rosCurrency identifier.Currency) (identifier.Currency, error) {
-			return GenericCurrency, nil
+		CurrencyFunc: func(rosCurrency identifier.Currency) (string, uint, error) {
+			return GenericCurrency.Symbol, GenericCurrency.Decimals, nil
 		},
 	}
 
 	return &v
 }
 
-func (v *Validator) Account(rosAccountID identifier.Account) error {
+func (v *Validator) Account(rosAccountID identifier.Account) (flow.Address, error) {
 	return v.AccountFunc(rosAccountID)
 }
 
-func (v *Validator) Block(rosBlockID identifier.Block) (identifier.Block, error) {
+func (v *Validator) Block(rosBlockID identifier.Block) (uint64, flow.Identifier, error) {
 	return v.BlockFunc(rosBlockID)
 }
 
-func (v *Validator) Transaction(rosTxID identifier.Transaction) error {
+func (v *Validator) Transaction(rosTxID identifier.Transaction) (flow.Identifier, error) {
 	return v.TransactionFunc(rosTxID)
 }
 
-func (v *Validator) Currency(rosCurrency identifier.Currency) (identifier.Currency, error) {
+func (v *Validator) Currency(rosCurrency identifier.Currency) (string, uint, error) {
 	return v.CurrencyFunc(rosCurrency)
 }


### PR DESCRIPTION
## Goal of this PR

This PR changes the Rosetta retriever to use shared code to get a Rosetta transaction from a Flow transaction ID and a list of events. This allows us to re-use the events list in the block endpoint, while it can use the same code in the transaction endpoint.

This allowed me to easily implement proper indices for Rosetta operations, which will now deterministically have the same indices, starting at zero, for all supported event types. At the same time, the network index is populated with the previous value that came from the Flow event type.

While implementing this, I realized that I could also clean up the validator interface to return native Flow types from the Rosetta identifiers, and use that to have cleaner retriever functions.

Fixes #347.

## Checklist

- [x] Is on the right branch
- [] ~Documentation is up-to-date~
- [] Tests are up-to-date