### PR TITLE
Remove related operations from Rosetta

### DIFF
--- a/api/rosetta/block_integration_test.go
+++ b/api/rosetta/block_integration_test.go
@@ -497,10 +497,6 @@ func validateTransfer(t *testing.T, hash string, from string, to string, amount 
 
 		assert.Equal(t, op1.Amount.Value, wantValue)
 
-		if assert.Len(t, op1.RelatedIDs, 1) {
-			assert.Equal(t, op1.RelatedIDs[0], op2.ID)
-		}
-
 		assert.Equal(t, op2.Type, dps.OperationTransfer)
 		assert.Equal(t, op2.Status, dps.StatusCompleted)
 
@@ -518,9 +514,5 @@ func validateTransfer(t *testing.T, hash string, from string, to string, amount 
 		}
 
 		assert.Equal(t, op2.Amount.Value, wantValue)
-
-		if assert.Len(t, op2.RelatedIDs, 1) {
-			assert.Equal(t, op2.RelatedIDs[0], op1.ID)
-		}
 	}
 }

--- a/rosetta/object/operation.go
+++ b/rosetta/object/operation.go
@@ -31,10 +31,9 @@ import (
 // The `coin_change` field is omitted, as the Flow blockchain is an
 // account-based blockchain without utxo set.
 type Operation struct {
-	ID         identifier.Operation   `json:"operation_identifier"`
-	RelatedIDs []identifier.Operation `json:"related_operations"`
-	Type       string                 `json:"type"`
-	Status     string                 `json:"status"`
-	AccountID  identifier.Account     `json:"account"`
-	Amount     Amount                 `json:"amount"`
+	ID        identifier.Operation `json:"operation_identifier"`
+	Type      string               `json:"type"`
+	Status    string               `json:"status"`
+	AccountID identifier.Account   `json:"account"`
+	Amount    Amount               `json:"amount"`
 }

--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -358,16 +358,5 @@ func (r *Retriever) operations(txID flow.Identifier, events []flow.Event) ([]*ob
 		ops = append(ops, op)
 	}
 
-	// Finally, we want the operations within a transaction to be related to each
-	// other.
-	for _, op1 := range ops {
-		for _, op2 := range ops {
-			if op1.ID.Index == op2.ID.Index {
-				continue
-			}
-			op1.RelatedIDs = append(op1.RelatedIDs, op2.ID)
-		}
-	}
-
 	return ops, nil
 }

--- a/rosetta/retriever/retriever_test.go
+++ b/rosetta/retriever/retriever_test.go
@@ -380,7 +380,6 @@ func TestRetriever_Block(t *testing.T) {
 				op = mocks.GenericOperation(1)
 			}
 
-			op.RelatedIDs = nil // unset RelatedIDs to prevent having duplicate related IDs.
 			return &op, nil
 		}
 
@@ -444,7 +443,6 @@ func TestRetriever_Block(t *testing.T) {
 				op = mocks.GenericOperation(1)
 			}
 
-			op.RelatedIDs = nil // unset RelatedIDs to prevent having duplicate related IDs.
 			return &op, nil
 		}
 
@@ -505,7 +503,6 @@ func TestRetriever_Block(t *testing.T) {
 				op = mocks.GenericOperation(1)
 			}
 
-			op.RelatedIDs = nil // unset RelatedIDs to prevent having duplicate related IDs.
 			return &op, nil
 		}
 
@@ -726,7 +723,6 @@ func TestRetriever_Transaction(t *testing.T) {
 				op = mocks.GenericOperation(1)
 			}
 
-			op.RelatedIDs = nil // unset RelatedIDs to prevent having duplicate related IDs.
 			return &op, nil
 		}
 
@@ -925,7 +921,6 @@ func baselineRetriever(t *testing.T) (*Retriever, error) {
 			op = mocks.GenericOperation(1)
 		}
 
-		op.RelatedIDs = nil // unset RelatedIDs to prevent having duplicate related IDs.
 		return &op, nil
 	}
 

--- a/testing/mocks/generic.go
+++ b/testing/mocks/generic.go
@@ -383,15 +383,6 @@ func GenericOperations(number int) []object.Operation {
 			},
 		}
 
-		// Inject RelatedIDs.
-		for j := 0; j < number; j++ {
-			if j == i {
-				continue
-			}
-
-			operation.RelatedIDs = append(operation.RelatedIDs, identifier.Operation{Index: uint(j)})
-		}
-
 		operations = append(operations, operation)
 	}
 


### PR DESCRIPTION
## Goal of this PR

Apparently related operations must have a certain chronological order and are not used to put together operations within the same transaction, but rather across shards or something. Anyway, I removed it...

## Checklist

- [x] Is on the right branch
- [ ] ~Documentation is up-to-date~
- [x] Tests are up-to-date