### PR TITLE
Verify lengths of byte slices in Chain

### DIFF
--- a/service/chain/disk.go
+++ b/service/chain/disk.go
@@ -68,9 +68,6 @@ func (d *Disk) Commit(height uint64) (flow.StateCommitment, error) {
 	if err != nil {
 		return flow.StateCommitment{}, fmt.Errorf("could not look up commit: %w", err)
 	}
-	if len(commit) != 32 {
-		return flow.StateCommitment{}, fmt.Errorf("invalid commit length: got %d want 32", len(commit))
-	}
 
 	return commit, nil
 }

--- a/service/chain/disk.go
+++ b/service/chain/disk.go
@@ -68,6 +68,9 @@ func (d *Disk) Commit(height uint64) (flow.StateCommitment, error) {
 	if err != nil {
 		return flow.StateCommitment{}, fmt.Errorf("could not look up commit: %w", err)
 	}
+	if len(commit) != 32 {
+		return flow.StateCommitment{}, fmt.Errorf("invalid commit length: got %d want 32", len(commit))
+	}
 
 	return commit, nil
 }

--- a/service/feeder/disk.go
+++ b/service/feeder/disk.go
@@ -67,12 +67,8 @@ func (d *Disk) Update() (*ledger.TrieUpdate, error) {
 			continue
 		}
 
-		// However, we need to make sure that all slices are copied, because the
-		// decode function will reuse the underlying slices later.
-		update = clone(update)
-
 		// For older versions, we need to verify the length of types that are aliased
-		// to the hash.Hash type from Flow-Go, because it is a slice instead of
+		// to the hash.Hash type from Flow Go, because it is a slice instead of
 		// a fixed-length byte array.
 		if len(update.RootHash) != 32 {
 			return nil, fmt.Errorf("invalid ledger root hash length in trie update: got %d want 32", len(update.RootHash))
@@ -82,6 +78,10 @@ func (d *Disk) Update() (*ledger.TrieUpdate, error) {
 				return nil, fmt.Errorf("invalid ledger path length in trie update: got %d want 32", len(path))
 			}
 		}
+
+		// However, we need to make sure that all slices are copied, because the
+		// decode function will reuse the underlying slices later.
+		update = clone(update)
 
 		return update, nil
 	}

--- a/service/feeder/disk.go
+++ b/service/feeder/disk.go
@@ -71,6 +71,18 @@ func (d *Disk) Update() (*ledger.TrieUpdate, error) {
 		// decode function will reuse the underlying slices later.
 		update = clone(update)
 
+		// For older versions, we need to verify the length of types that are aliased
+		// to the hash.Hash type from Flow-Go, because it is a slice instead of
+		// a fixed-length byte array.
+		if len(update.RootHash) != 32 {
+			return nil, fmt.Errorf("invalid ledger root hash length in trie update: got %d want 32", len(update.RootHash))
+		}
+		for _, path := range update.Paths {
+			if len(path) != 32 {
+				return nil, fmt.Errorf("invalid ledger path length in trie update: got %d want 32", len(path))
+			}
+		}
+
 		return update, nil
 	}
 }


### PR DESCRIPTION
## Goal of this PR

Fixes #242 

Unfortunately this adds untestable code to master, while it could be testable on spork branches.

Should the feeder also be tested similarly? We could check the lengths of the RootHash and each Path within the trie updates.

Also these changes make my IDE freak out on master since it doesn't understand why we're checking the length of arrays :p

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date