### PR TITLE
Indexer: work-around for duplicate transactions

### DIFF
--- a/cmd/check-duplicate-transactions/main.go
+++ b/cmd/check-duplicate-transactions/main.go
@@ -50,8 +50,8 @@ func run() int {
 		flagLevel string
 	)
 
-	pflag.StringVarP(&flagData, "data", "d", "data", "database directory for protocol state")
-	pflag.StringVarP(&flagIndex, "index", "i", "index", "database directory for state index")
+	pflag.StringVarP(&flagData, "data", "d", "", "database directory for protocol state")
+	pflag.StringVarP(&flagIndex, "index", "i", "", "database directory for state index")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 
 	pflag.Parse()

--- a/cmd/check-duplicate-transactions/main.go
+++ b/cmd/check-duplicate-transactions/main.go
@@ -40,12 +40,12 @@ func run() int {
 
 	// Parse the command line arguments.
 	var (
-		flagIndex   string
+		flagData    string
 		flagLevel   string
 		flagHeights []uint
 	)
 
-	pflag.StringVarP(&flagIndex, "index", "i", "index", "database directory for state index")
+	pflag.StringVarP(&flagData, "data", "d", "data", "database directory for protocol state")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 	pflag.UintSliceVarP(&flagHeights, "heights", "h", []uint{}, "heights to check for duplicate transactions")
 
@@ -62,9 +62,9 @@ func run() int {
 	log = log.Level(level)
 
 	// Open the index database.
-	db, err := badger.Open(dps.DefaultOptions(flagIndex).WithReadOnly(true).WithBypassLockGuard(true))
+	db, err := badger.Open(dps.DefaultOptions(flagData).WithReadOnly(true).WithBypassLockGuard(true))
 	if err != nil {
-		log.Error().Str("index", flagIndex).Err(err).Msg("could not open badger db")
+		log.Error().Str("data", flagData).Err(err).Msg("could not open protocol state")
 		return failure
 	}
 	defer db.Close()

--- a/cmd/check-duplicate-transactions/main.go
+++ b/cmd/check-duplicate-transactions/main.go
@@ -101,7 +101,6 @@ func run() int {
 			var blockID flow.Identifier
 			err = db.View(operation.LookupBlockHeight(uint64(height), &blockID))
 			if errors.Is(err, storerr.ErrNotFound) {
-				log.Info().Msg("duplicate transaction check finished")
 				break
 			}
 			if err != nil {
@@ -147,6 +146,8 @@ func run() int {
 				}
 			}
 		}
+
+		log.Info().Msg("protocol state duplicate check complete")
 	}
 
 	// Only check the state index if a directory for it is given.
@@ -181,6 +182,9 @@ func run() int {
 			// height => txIDs
 			var txIDs []flow.Identifier
 			err = db.View(lib.LookupTransactionsForHeight(height, &txIDs))
+			if errors.Is(err, badger.ErrKeyNotFound) {
+				break
+			}
 			if err != nil {
 				log.Error().Err(err).Msg("could not look up payload guarantees")
 				return failure
@@ -201,6 +205,8 @@ func run() int {
 				log.Debug().Msg("transaction not duplicated")
 			}
 		}
+
+		log.Info().Msg("index state duplicate check complete")
 	}
 
 	return success

--- a/cmd/check-duplicate-transactions/main.go
+++ b/cmd/check-duplicate-transactions/main.go
@@ -75,6 +75,8 @@ func run() int {
 	// Only check the protocol state if a directory for it is given.
 	if flagData != "" {
 
+		log.Info().Str("data", flagData).Msg("starting protocol state duplicate check")
+
 		// Open the index database.
 		db, err := badger.Open(dps.DefaultOptions(flagData).WithReadOnly(true).WithBypassLockGuard(true))
 		if err != nil {
@@ -147,11 +149,15 @@ func run() int {
 			}
 		}
 
+		_ = db.Close()
+
 		log.Info().Msg("protocol state duplicate check complete")
 	}
 
 	// Only check the state index if a directory for it is given.
 	if flagIndex != "" {
+
+		log.Info().Str("index", flagIndex).Msg("starting index state duplicate check")
 
 		// Open the index database.
 		db, err := badger.Open(dps.DefaultOptions(flagIndex).WithReadOnly(true).WithBypassLockGuard(true))
@@ -205,6 +211,8 @@ func run() int {
 				log.Debug().Msg("transaction not duplicated")
 			}
 		}
+
+		_ = db.Close()
 
 		log.Info().Msg("index state duplicate check complete")
 	}

--- a/cmd/check-duplicate-transactions/main.go
+++ b/cmd/check-duplicate-transactions/main.go
@@ -82,7 +82,7 @@ func run() int {
 	for height := root; ; height++ {
 		txIDs := make(map[flow.Identifier]flow.Identifier)
 
-		log = log.With().Uint64("height", height).Logger()
+		log := log.With().Uint64("height", height).Logger()
 
 		// height => blockID
 		var blockID flow.Identifier
@@ -108,7 +108,7 @@ func run() int {
 
 		for _, collID := range collIDs {
 
-			log = log.With().Hex("collection", collID[:]).Logger()
+			log := log.With().Hex("collection", collID[:]).Logger()
 
 			// collID => txIDs
 			var collection flow.LightCollection
@@ -121,7 +121,7 @@ func run() int {
 			// txID ? duplicate
 			for _, txID := range collection.Transactions {
 
-				log = log.With().Hex("transaction", txID[:]).Logger()
+				log := log.With().Hex("transaction", txID[:]).Logger()
 
 				altID, ok := txIDs[txID]
 				if ok {

--- a/cmd/check-duplicate-transactions/main.go
+++ b/cmd/check-duplicate-transactions/main.go
@@ -112,7 +112,7 @@ func run() int {
 
 				altID, ok := txIDs[txID]
 				if ok {
-					log.Info().Hex("collection", collID[:]).Hex("alternative", altID[:]).Hex("transaction", txID[:])
+					log.Info().Hex("alternative", altID[:]).Msg("duplicate transaction detected")
 					continue
 				}
 

--- a/cmd/check-duplicate-transactions/main.go
+++ b/cmd/check-duplicate-transactions/main.go
@@ -1,0 +1,125 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage/badger/operation"
+	"github.com/rs/zerolog"
+	"github.com/spf13/pflag"
+
+	"github.com/optakt/flow-dps/models/dps"
+)
+
+const (
+	success = 0
+	failure = 1
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+
+	// Parse the command line arguments.
+	var (
+		flagIndex   string
+		flagLevel   string
+		flagHeights []uint
+	)
+
+	pflag.StringVarP(&flagIndex, "index", "i", "index", "database directory for state index")
+	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
+	pflag.UintSliceVarP(&flagHeights, "heights", "h", []uint{}, "heights to check for duplicate transactions")
+
+	pflag.Parse()
+
+	// Initialize the logger.
+	zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
+	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.DebugLevel)
+	level, err := zerolog.ParseLevel(flagLevel)
+	if err != nil {
+		log.Error().Str("level", flagLevel).Err(err).Msg("could not parse log level")
+		return failure
+	}
+	log = log.Level(level)
+
+	// Open the index database.
+	db, err := badger.Open(dps.DefaultOptions(flagIndex).WithReadOnly(true).WithBypassLockGuard(true))
+	if err != nil {
+		log.Error().Str("index", flagIndex).Err(err).Msg("could not open badger db")
+		return failure
+	}
+	defer db.Close()
+
+	// Go through each height, retrieve the transactions from the DB and check for duplicates.
+	for _, height := range flagHeights {
+		txIDs := make(map[flow.Identifier]flow.Identifier)
+
+		log = log.With().Uint("height", height).Logger()
+
+		// height => blockID
+		var blockID flow.Identifier
+		err = db.View(operation.LookupBlockHeight(uint64(height), &blockID))
+		if err != nil {
+			log.Error().Uint("height", height).Err(err).Msg("could not look up height")
+			return failure
+		}
+
+		log = log.With().Hex("block", blockID[:]).Logger()
+
+		// blockID => collIDs
+		var collIDs []flow.Identifier
+		err = db.View(operation.LookupPayloadGuarantees(blockID, &collIDs))
+		if err != nil {
+			log.Error().Err(err).Msg("could not look up payload guarantees")
+			return failure
+		}
+
+		for _, collID := range collIDs {
+
+			log = log.With().Hex("collection", collID[:]).Logger()
+
+			// collID => txIDs
+			var collection flow.LightCollection
+			err := db.View(operation.RetrieveCollection(collID, &collection))
+			if err != nil {
+				log.Error().Msg("could not retrieve collection")
+				return failure
+			}
+
+			// txID ? duplicate
+			for _, txID := range collection.Transactions {
+
+				log = log.With().Hex("transaction", txID[:]).Logger()
+
+				altID, ok := txIDs[txID]
+				if ok {
+					log.Info().Hex("collection", collID[:]).Hex("alternative", altID[:]).Hex("transaction", txID[:])
+					continue
+				}
+
+				txIDs[txID] = collID
+			}
+		}
+	}
+
+	return success
+}

--- a/service/index/reader.go
+++ b/service/index/reader.go
@@ -167,6 +167,7 @@ func (r *Reader) TransactionsByHeight(height uint64) ([]flow.Identifier, error) 
 			continue
 		}
 		idSet = append(idSet, txID)
+		skip[txID] = struct{}{}
 	}
 
 	return idSet, err

--- a/service/storage/auxiliary.go
+++ b/service/storage/auxiliary.go
@@ -54,18 +54,22 @@ func Combine(ops ...func(*badger.Txn) error) func(*badger.Txn) error {
 	}
 }
 
-func (l *Library) retrieve(key []byte, value interface{}) func(tx *badger.Txn) error {
+func (l *Library) retrieve(key []byte, v interface{}) func(tx *badger.Txn) error {
+	// NOTE: When retrieving things from the database, it's important that the
+	// variable is initialized within a loop body if the retrieval happens as
+	// part of a loop. This makes sure that the value we decode into always has
+	// it's own independent memory location.
 	return func(tx *badger.Txn) error {
 		item, err := tx.Get(key)
 		if err != nil {
-			return fmt.Errorf("could not retrieve value at %x: %w", key, err)
+			return fmt.Errorf("could not get value (key: %x): %w", key, err)
 		}
 
-		err = item.Value(func(b []byte) error {
-			return l.codec.Unmarshal(b, value)
+		err = item.Value(func(val []byte) error {
+			return l.codec.Unmarshal(val, v)
 		})
 		if err != nil {
-			return fmt.Errorf("could not retrieve value at %x: %w", key, err)
+			return fmt.Errorf("could not decode value (key: %x): %w", key, err)
 		}
 
 		return nil
@@ -73,12 +77,16 @@ func (l *Library) retrieve(key []byte, value interface{}) func(tx *badger.Txn) e
 }
 
 func (l *Library) save(key []byte, value interface{}) func(*badger.Txn) error {
+	// NOTE: We want to encode the value right away, rather than doing it inside
+	// of the closure. Otherwise, if value is a loop variable, it might not be
+	// the same underlying value anymore when iterating through the list by the
+	// time that the closure is called in the Badger transaction.
+	val, err := l.codec.Marshal(value)
 	return func(tx *badger.Txn) error {
-		b, err := l.codec.Marshal(value)
 		if err != nil {
-			return fmt.Errorf("could not encode value at %x: %w", key, err)
+			return fmt.Errorf("could not encode value (key: %x): %w", key, err)
 		}
 
-		return tx.Set(key, b)
+		return tx.Set(key, val)
 	}
 }

--- a/service/storage/operations_test.go
+++ b/service/storage/operations_test.go
@@ -1243,6 +1243,7 @@ func TestIndexAndLookup_Seals(t *testing.T) {
 
 		var got []flow.Identifier
 		err = db.View(l.LookupSealsForHeight(mocks.GenericHeight, &got))
+		require.NoError(t, err)
 
 		assert.Equal(t, 1, decodeCallCount)
 	})


### PR DESCRIPTION
## Goal of this PR

There was a potentially subtle closure bug around loop variables and Badger transaction closures. However, after going through the code, I'm not sure it is related though.

## Checklist

- [x] Is on the right branch
- [ ] ~Documentation is up-to-date~
- [ ] ~Tests are up-to-date~