### PR TITLE
Rosetta: return zero balance for missing vaults

### DIFF
--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -142,7 +142,7 @@ func (r *Retriever) Balances(rosBlockID identifier.Block, rosAccountID identifie
 	amounts := make([]object.Amount, 0, len(symbols))
 	for _, symbol := range symbols {
 
-		// We get the script to get the vault balance and execute it.
+		// We generate the script to get the vault balance and execute it.
 		script, err := r.generator.GetBalance(symbol)
 		if err != nil {
 			return identifier.Block{}, nil, fmt.Errorf("could not generate script: %w", err)


### PR DESCRIPTION
## Goal of this PR

Apparently Rosetta checks balances for random accounts sometimes. A missing vault can not be an error, so we just consider accounts without vault to have a zero balance.

## Checklist

- [x] Is on the right branch
- [ ] ~Documentation is up-to-date~
- [ ] ~Tests are up-to-date~