### PR TITLE
Fix duplicate transactions for real

### DIFF
--- a/service/index/reader.go
+++ b/service/index/reader.go
@@ -154,25 +154,7 @@ func (r *Reader) HeightForTransaction(txID flow.Identifier) (uint64, error) {
 func (r *Reader) TransactionsByHeight(height uint64) ([]flow.Identifier, error) {
 	var txIDs []flow.Identifier
 	err := r.db.View(r.lib.LookupTransactionsForHeight(height, &txIDs))
-
-	// TODO: There is a bug somewhere between when we read from the protocol
-	// state and when we write to the state index. In rare cases, it introduces
-	// duplicate transaction IDs into the database. Until that bug is identified
-	// and fixed, this is a work-around, see:
-	// => https://github.com/optakt/flow-dps/issues/351
-	// => https://github.com/optakt/flow-dps/issues/352
-	idSet := make([]flow.Identifier, 0, len(txIDs))
-	seen := make(map[flow.Identifier]struct{})
-	for _, txID := range txIDs {
-		_, ok := seen[txID]
-		if ok {
-			continue
-		}
-		idSet = append(idSet, txID)
-		seen[txID] = struct{}{}
-	}
-
-	return idSet, err
+	return txIDs, err
 }
 
 // Result returns the transaction result for the given transaction ID.

--- a/service/index/writer.go
+++ b/service/index/writer.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/hashicorp/go-multierror"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/onflow/flow-go/ledger"
@@ -56,7 +57,7 @@ func NewWriter(db *badger.DB, lib dps.WriteLibrary, options ...func(*Config)) *W
 		cfg:  cfg,
 		tx:   db.NewTransaction(true),
 		sema: semaphore.NewWeighted(int64(cfg.ConcurrentTransactions)),
-		err:  make(chan error),
+		err:  make(chan error, cfg.ConcurrentTransactions),
 	}
 
 	return &w
@@ -227,9 +228,8 @@ func (w *Writer) Seals(height uint64, seals []*flow.Seal) error {
 func (w *Writer) apply(op func(*badger.Txn) error) error {
 
 	// Before applying an additional operation to the transaction we are
-	// currently building, we want to see if there was an error committing the
-	// previous transaction. As it is set in a callback, we copy the error while
-	// guarded with a read lock.
+	// currently building, we want to see if there was an error committing any
+	// previous transaction.
 	select {
 	case err := <-w.err:
 		return fmt.Errorf("could not commit transaction: %w", err)
@@ -259,8 +259,8 @@ func (w *Writer) apply(op func(*badger.Txn) error) error {
 func (w *Writer) done(err error) {
 
 	// When a transaction is fully committed, we get the result in this
-	// callback. If we have an error, we acquire the write lock for the error
-	// and store it.
+	// callback. In case of an error, we pipe it to the apply function through
+	// the error channel.
 	if err != nil {
 		w.err <- err
 	}
@@ -284,17 +284,15 @@ func (w *Writer) Close() error {
 		return fmt.Errorf("could not commit final transaction: %w", err)
 	}
 
-	// When closing the writer, we should no longer be applying operations. This
-	// means we only have to wait for all inflight transactions to commit. This
-	// is guaranteed if we are able to acquire all of the resources on the
-	// semaphore, which we do here.
+	// Once we acquire all semaphore resources, it means all transactions have
+	// been committed. We can now close the error channel and drain any
+	// remaining errors.
 	_ = w.sema.Acquire(context.Background(), int64(w.cfg.ConcurrentTransactions))
-	select {
-	case err := <-w.err:
-		return fmt.Errorf("could not flush remaining transactions: %w", err)
-	default:
-		// skip
+	close(w.err)
+	var merr *multierror.Error
+	for err := range w.err {
+		merr = multierror.Append(merr, err)
 	}
 
-	return nil
+	return merr.ErrorOrNil()
 }

--- a/service/storage/auxiliary.go
+++ b/service/storage/auxiliary.go
@@ -55,10 +55,6 @@ func Combine(ops ...func(*badger.Txn) error) func(*badger.Txn) error {
 }
 
 func (l *Library) retrieve(key []byte, v interface{}) func(tx *badger.Txn) error {
-	// NOTE: When retrieving things from the database, it's important that the
-	// variable is initialized within the loop body if the retrieval happens as
-	// part of a loop. This makes sure that the value we decode into always has
-	// its own independent memory location.
 	return func(tx *badger.Txn) error {
 		item, err := tx.Get(key)
 		if err != nil {
@@ -77,12 +73,8 @@ func (l *Library) retrieve(key []byte, v interface{}) func(tx *badger.Txn) error
 }
 
 func (l *Library) save(key []byte, value interface{}) func(*badger.Txn) error {
-	// NOTE: We want to encode the value right away, rather than doing it inside
-	// of the closure. Otherwise, if value is a loop variable, it might not be
-	// the same underlying value anymore when iterating through the list by the
-	// time that the closure is called in the Badger transaction.
-	val, err := l.codec.Marshal(value)
 	return func(tx *badger.Txn) error {
+		val, err := l.codec.Marshal(value)
 		if err != nil {
 			return fmt.Errorf("could not encode value (key: %x): %w", key, err)
 		}


### PR DESCRIPTION
## Goal of this PR

This PR fixes a _very_ subtle around error handling with transactions. It solves both the following error:

```json
"could not apply transition to state: could not index commit: could not apply operation: could not encode value (key: 040000000000eac5ba): Txn is too big to fit into one request"
```

... as well as the duplicate transaction error, as follows:

1) We can apply operations to a transaction twice when an error is placed into `w.err` before we actually check the error.

2) We can get a strange encoding error if an error is placed into the error returned by the encoding function before the error is actually checked on the next line.

3) Similarly, we can encounter other weird behaviour if a `nil` is placed into the operation's error before the error is checked.

The solution is to get rid of the error field on the struct, and instead replace it with a channel that can queue as many errors as we can execute transactions concurrently.


Fixes #351.

Fixes #352.

## Checklist

- [x] Is on the right branch
- [ ] ~Documentation is up-to-date~
- [ ] ~Tests are up-to-date~