### PR TITLE
Rosetta: Retrieve account sequence number

### DIFF
--- a/api/access/invoker.go
+++ b/api/access/invoker.go
@@ -20,6 +20,6 @@ import (
 )
 
 type Invoker interface {
-	GetAccount(address flow.Address, height uint64) (*flow.Account, error)
+	Account(address flow.Address, height uint64) (*flow.Account, error)
 	Script(height uint64, script []byte, parameters []cadence.Value) (cadence.Value, error)
 }

--- a/api/access/server.go
+++ b/api/access/server.go
@@ -319,7 +319,7 @@ func (s *Server) GetAccountAtLatestBlock(ctx context.Context, in *access.GetAcco
 }
 
 func (s *Server) GetAccountAtBlockHeight(_ context.Context, in *access.GetAccountAtBlockHeightRequest) (*access.AccountResponse, error) {
-	account, err := s.invoker.GetAccount(flow.BytesToAddress(in.Address), in.BlockHeight)
+	account, err := s.invoker.Account(flow.BytesToAddress(in.Address), in.BlockHeight)
 	if err != nil {
 		return nil, fmt.Errorf("could not get account: %w", err)
 	}

--- a/api/access/server_test.go
+++ b/api/access/server_test.go
@@ -853,7 +853,7 @@ func TestServer_GetAccount(t *testing.T) {
 		}
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.GetAccountFunc = func(address flow.Address, height uint64) (*flow.Account, error) {
+		invoker.AccountFunc = func(address flow.Address, height uint64) (*flow.Account, error) {
 			assert.Equal(t, mocks.GenericAccount.Address, address)
 			assert.Equal(t, mocks.GenericHeight, height)
 
@@ -895,7 +895,7 @@ func TestServer_GetAccount(t *testing.T) {
 		t.Parallel()
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.GetAccountFunc = func(flow.Address, uint64) (*flow.Account, error) {
+		invoker.AccountFunc = func(flow.Address, uint64) (*flow.Account, error) {
 			return nil, mocks.GenericError
 		}
 
@@ -921,7 +921,7 @@ func TestServer_GetAccountAtLatestBlock(t *testing.T) {
 		}
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.GetAccountFunc = func(address flow.Address, height uint64) (*flow.Account, error) {
+		invoker.AccountFunc = func(address flow.Address, height uint64) (*flow.Account, error) {
 			assert.Equal(t, mocks.GenericAccount.Address, address)
 			assert.Equal(t, mocks.GenericHeight, height)
 
@@ -963,7 +963,7 @@ func TestServer_GetAccountAtLatestBlock(t *testing.T) {
 		t.Parallel()
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.GetAccountFunc = func(flow.Address, uint64) (*flow.Account, error) {
+		invoker.AccountFunc = func(flow.Address, uint64) (*flow.Account, error) {
 			return nil, mocks.GenericError
 		}
 
@@ -989,7 +989,7 @@ func TestServer_GetAccountAtBlockHeight(t *testing.T) {
 		}
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.GetAccountFunc = func(address flow.Address, height uint64) (*flow.Account, error) {
+		invoker.AccountFunc = func(address flow.Address, height uint64) (*flow.Account, error) {
 			assert.Equal(t, mocks.GenericAccount.Address, address)
 			assert.Equal(t, mocks.GenericHeight+999, height)
 
@@ -1017,7 +1017,7 @@ func TestServer_GetAccountAtBlockHeight(t *testing.T) {
 		t.Parallel()
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.GetAccountFunc = func(flow.Address, uint64) (*flow.Account, error) {
+		invoker.AccountFunc = func(flow.Address, uint64) (*flow.Account, error) {
 			return nil, mocks.GenericError
 		}
 

--- a/api/rosetta/errors.go
+++ b/api/rosetta/errors.go
@@ -15,7 +15,7 @@
 package rosetta
 
 import (
-	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go/model/flow"
 
 	"github.com/optakt/flow-dps/rosetta/configuration"
 	"github.com/optakt/flow-dps/rosetta/failure"

--- a/api/rosetta/errors.go
+++ b/api/rosetta/errors.go
@@ -271,3 +271,12 @@ func invalidSignature(fail failure.InvalidSignature) Error {
 		fail.Description,
 	)
 }
+
+func invalidProposalKey(fail failure.InvalidProposalKey) Error {
+	return convertError(
+		configuration.ErrorInvalidProposalKey,
+		fail.Description,
+		withAddress("account", fail.Address),
+		withDetail("index", fail.Index),
+	)
+}

--- a/api/rosetta/metadata.go
+++ b/api/rosetta/metadata.go
@@ -79,7 +79,7 @@ func (c *Construction) Metadata(ctx echo.Context) error {
 
 	// TODO: Allow arbitrary proposal key index
 	// => https://github.com/optakt/flow-dps/issues/369
-	sequenceNr, err := c.retrieve.AccountSequenceNumber(req.Options.AccountID, 0)
+	sequenceNr, err := c.retrieve.SequenceNumber(req.Options.AccountID, 0)
 	var iaErr failure.InvalidAccount
 	if errors.As(err, &iaErr) {
 		return echo.NewHTTPError(http.StatusUnprocessableEntity, invalidAccount(iaErr))

--- a/api/rosetta/retriever.go
+++ b/api/rosetta/retriever.go
@@ -27,5 +27,5 @@ type Retriever interface {
 	Block(rosBlockID identifier.Block) (*object.Block, []identifier.Transaction, error)
 	Transaction(rosBlockID identifier.Block, rosTxID identifier.Transaction) (*object.Transaction, error)
 	Balances(rosBlockID identifier.Block, rosAccountID identifier.Account, rosCurrencies []identifier.Currency) (identifier.Block, []object.Amount, error)
-	AccountSequenceNumber(rosAccountID identifier.Account, keyIndex int) (uint64, error)
+	SequenceNumber(rosAccountID identifier.Account, keyIndex int) (uint64, error)
 }

--- a/api/rosetta/retriever.go
+++ b/api/rosetta/retriever.go
@@ -27,4 +27,5 @@ type Retriever interface {
 	Block(rosBlockID identifier.Block) (*object.Block, []identifier.Transaction, error)
 	Transaction(rosBlockID identifier.Block, rosTxID identifier.Transaction) (*object.Transaction, error)
 	Balances(rosBlockID identifier.Block, rosAccountID identifier.Account, rosCurrencies []identifier.Currency) (identifier.Block, []object.Amount, error)
+	AccountSequenceNumber(rosAccountID identifier.Account, keyIndex int) (uint64, error)
 }

--- a/invoker/invoker.go
+++ b/invoker/invoker.go
@@ -126,7 +126,7 @@ func (i *Invoker) Script(height uint64, script []byte, arguments []cadence.Value
 	return proc.Value, nil
 }
 
-func (i *Invoker) GetAccount(address flow.Address, height uint64) (*flow.Account, error) {
+func (i *Invoker) Account(address flow.Address, height uint64) (*flow.Account, error) {
 	// Look up the current block and commit for the block.
 	header, err := i.index.Header(height)
 	if err != nil {

--- a/invoker/invoker_test.go
+++ b/invoker/invoker_test.go
@@ -151,7 +151,7 @@ func TestInvoker_Script(t *testing.T) {
 	})
 }
 
-func TestInvoker_GetAccount(t *testing.T) {
+func TestInvoker_Account(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
@@ -176,7 +176,7 @@ func TestInvoker_GetAccount(t *testing.T) {
 		invoker.vm = vm
 		invoker.index = index
 
-		account, err := invoker.GetAccount(mocks.GenericAccount.Address, mocks.GenericHeight)
+		account, err := invoker.Account(mocks.GenericAccount.Address, mocks.GenericHeight)
 
 		assert.NoError(t, err)
 		assert.Equal(t, &mocks.GenericAccount, account)
@@ -193,12 +193,12 @@ func TestInvoker_GetAccount(t *testing.T) {
 		invoker := baselineInvoker(t)
 		invoker.index = index
 
-		_, err := invoker.GetAccount(mocks.GenericAccount.Address, mocks.GenericHeight)
+		_, err := invoker.Account(mocks.GenericAccount.Address, mocks.GenericHeight)
 
 		assert.Error(t, err)
 	})
 
-	t.Run("handles vm failure on GetAccount", func(t *testing.T) {
+	t.Run("handles vm failure on Account", func(t *testing.T) {
 		t.Parallel()
 
 		vm := mocks.BaselineVirtualMachine(t)
@@ -209,7 +209,7 @@ func TestInvoker_GetAccount(t *testing.T) {
 		invoker := baselineInvoker(t)
 		invoker.vm = vm
 
-		_, err := invoker.GetAccount(mocks.GenericAccount.Address, mocks.GenericHeight)
+		_, err := invoker.Account(mocks.GenericAccount.Address, mocks.GenericHeight)
 
 		assert.Error(t, err)
 	})

--- a/rosetta/configuration/errors.go
+++ b/rosetta/configuration/errors.go
@@ -41,4 +41,5 @@ var (
 	ErrorInvalidAmount            = meta.ErrorDefinition{Code: 18, Message: "invalid transaction amount", Retriable: false}
 	ErrorInvalidReceiver          = meta.ErrorDefinition{Code: 19, Message: "invalid transaction recipient", Retriable: false}
 	ErrorInvalidSignature         = meta.ErrorDefinition{Code: 20, Message: "invalid transaction signature", Retriable: false}
+	ErrorInvalidProposalKey       = meta.ErrorDefinition{Code: 21, Message: "invalid transaction proposal key", Retriable: false}
 )

--- a/rosetta/failure/invalid_payer.go
+++ b/rosetta/failure/invalid_payer.go
@@ -17,7 +17,7 @@ package failure
 import (
 	"fmt"
 
-	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 type InvalidPayer struct {

--- a/rosetta/failure/invalid_proposal_key.go
+++ b/rosetta/failure/invalid_proposal_key.go
@@ -27,5 +27,5 @@ type InvalidProposalKey struct {
 }
 
 func (i InvalidProposalKey) Error() string {
-	return fmt.Sprintf("invalid proposal key (address: %s, key index: %d): %s", i.Address.String(), i.Index, i.Description)
+	return fmt.Sprintf("invalid proposal key (address: %s, key index: %d): %s", i.Address, i.Index, i.Description)
 }

--- a/rosetta/failure/invalid_proposal_key.go
+++ b/rosetta/failure/invalid_proposal_key.go
@@ -12,14 +12,20 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package retriever
+package failure
 
 import (
-	"github.com/onflow/cadence"
-	"github.com/onflow/flow-go/model/flow"
+	"fmt"
+
+	"github.com/onflow/flow-go-sdk"
 )
 
-type Invoker interface {
-	Script(height uint64, script []byte, parameters []cadence.Value) (cadence.Value, error)
-	GetAccount(address flow.Address, height uint64) (*flow.Account, error)
+type InvalidProposalKey struct {
+	Description Description
+	Address     flow.Address
+	Index       int
+}
+
+func (i InvalidProposalKey) Error() string {
+	return fmt.Sprintf("invalid proposal key (address: %s, key index: %d): %s", i.Address.String(), i.Index, i.Description)
 }

--- a/rosetta/failure/invalid_proposer.go
+++ b/rosetta/failure/invalid_proposer.go
@@ -17,7 +17,7 @@ package failure
 import (
 	"fmt"
 
-	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 type InvalidProposer struct {

--- a/rosetta/retriever/invoker.go
+++ b/rosetta/retriever/invoker.go
@@ -21,5 +21,5 @@ import (
 
 type Invoker interface {
 	Script(height uint64, script []byte, parameters []cadence.Value) (cadence.Value, error)
-	GetAccount(address flow.Address, height uint64) (*flow.Account, error)
+	Account(address flow.Address, height uint64) (*flow.Account, error)
 }

--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -405,7 +405,7 @@ func (r *Retriever) SequenceNumber(rosAccountID identifier.Account, keyIndex int
 	}
 
 	// Retrieve the account at the latest block.
-	account, err := r.invoke.GetAccount(address, last)
+	account, err := r.invoke.Account(address, last)
 	if err != nil {
 		return 0, fmt.Errorf("could not retrieve account: %w", err)
 	}

--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -389,7 +389,7 @@ func (r *Retriever) operations(txID flow.Identifier, events []flow.Event) ([]*ob
 	return ops, nil
 }
 
-func (r *Retriever) AccountSequenceNumber(rosAccountID identifier.Account, keyIndex int) (uint64, error) {
+func (r *Retriever) SequenceNumber(rosAccountID identifier.Account, keyIndex int) (uint64, error) {
 
 	// Run validation on the account qualifier. If it is valid, this will return
 	// the associated Flow account address.

--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/onflow/cadence"
-	sdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go/model/flow"
 
 	"github.com/optakt/flow-dps/models/dps"
@@ -420,7 +419,7 @@ func (r *Retriever) SequenceNumber(rosAccountID identifier.Account, keyIndex int
 	key, ok := keys[keyIndex]
 	if !ok {
 		return 0, failure.InvalidProposalKey{
-			Address:     sdk.BytesToAddress(address[:]),
+			Address:     address,
 			Index:       keyIndex,
 			Description: failure.NewDescription("account key not found"),
 		}
@@ -429,7 +428,7 @@ func (r *Retriever) SequenceNumber(rosAccountID identifier.Account, keyIndex int
 	// Check if the key is still valid.
 	if key.Revoked {
 		return 0, failure.InvalidProposalKey{
-			Address:     sdk.BytesToAddress(address[:]),
+			Address:     address,
 			Index:       keyIndex,
 			Description: failure.NewDescription("account key was revoked"),
 		}

--- a/rosetta/transactions/convert.go
+++ b/rosetta/transactions/convert.go
@@ -12,20 +12,13 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package failure
+package transactions
 
 import (
-	"fmt"
-
+	sdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go/model/flow"
 )
 
-type InvalidProposalKey struct {
-	Description Description
-	Address     flow.Address
-	Index       int
-}
-
-func (i InvalidProposalKey) Error() string {
-	return fmt.Sprintf("invalid proposal key (address: %s, key index: %d): %s", i.Address.String(), i.Index, i.Description)
+func convertAddress(address sdk.Address) flow.Address {
+	return flow.BytesToAddress(address[:])
 }

--- a/rosetta/transactions/parse_transaction.go
+++ b/rosetta/transactions/parse_transaction.go
@@ -66,15 +66,15 @@ func (p *Parser) ParseTransaction(tx *flow.Transaction) ([]object.Operation, []i
 	// Verify that the sender is the payer and the proposer.
 	if tx.Payer != authorizer {
 		return nil, nil, failure.InvalidPayer{
-			Have:        tx.Payer,
-			Want:        authorizer,
+			Have:        convertAddress(tx.Payer),
+			Want:        convertAddress(authorizer),
 			Description: failure.NewDescription("invalid transaction payer"),
 		}
 	}
 	if tx.ProposalKey.Address != authorizer {
 		return nil, nil, failure.InvalidProposer{
-			Have:        tx.ProposalKey.Address,
-			Want:        authorizer,
+			Have:        convertAddress(tx.ProposalKey.Address),
+			Want:        convertAddress(authorizer),
 			Description: failure.NewDescription("invalid transaction proposer"),
 		}
 	}

--- a/testing/mocks/invoker.go
+++ b/testing/mocks/invoker.go
@@ -22,8 +22,8 @@ import (
 )
 
 type Invoker struct {
-	ScriptFunc     func(height uint64, script []byte, parameters []cadence.Value) (cadence.Value, error)
-	GetAccountFunc func(address flow.Address, height uint64) (*flow.Account, error)
+	ScriptFunc  func(height uint64, script []byte, parameters []cadence.Value) (cadence.Value, error)
+	AccountFunc func(address flow.Address, height uint64) (*flow.Account, error)
 }
 
 func BaselineInvoker(t *testing.T) *Invoker {
@@ -33,7 +33,7 @@ func BaselineInvoker(t *testing.T) *Invoker {
 		ScriptFunc: func(height uint64, script []byte, parameters []cadence.Value) (cadence.Value, error) {
 			return GenericAmount(0), nil
 		},
-		GetAccountFunc: func(address flow.Address, height uint64) (*flow.Account, error) {
+		AccountFunc: func(address flow.Address, height uint64) (*flow.Account, error) {
 			return &GenericAccount, nil
 		},
 	}
@@ -45,6 +45,6 @@ func (i *Invoker) Script(height uint64, script []byte, parameters []cadence.Valu
 	return i.ScriptFunc(height, script, parameters)
 }
 
-func (i *Invoker) GetAccount(address flow.Address, height uint64) (*flow.Account, error) {
-	return i.GetAccountFunc(address, height)
+func (i *Invoker) Account(address flow.Address, height uint64) (*flow.Account, error) {
+	return i.AccountFunc(address, height)
 }


### PR DESCRIPTION
This PR introduces functionality that was previously missing - retrieving sequence number for an account key, required for the Rosetta Construction API

## Checklist

- [x] Is on the right branch
- [ ] ~Documentation is up-to-date~
- [ ] ~Tests are up-to-date~