### PR TITLE
Verifying signature of parsed transactions

### DIFF
--- a/api/rosetta/errors.go
+++ b/api/rosetta/errors.go
@@ -57,7 +57,9 @@ const (
 	txEncoding              = "unable to encode transaction"
 	txParsing               = "unable to parse transaction"
 	txSigning               = "unable to sign transaction"
+	keyRetrieval            = "unable to retrieve account key"
 	payloadHashing          = "unable to hash signing payload"
+	signatureVerification   = "unable to verify signature"
 )
 
 // Error represents an error as defined by the Rosetta API specification. It

--- a/api/rosetta/parse.go
+++ b/api/rosetta/parse.go
@@ -134,6 +134,15 @@ func (c *Construction) Parse(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, internal(txParsing, err))
 	}
 
+	// Verify that the signature is actually valid.
+	err = c.transact.VerifySignature(&tx, signers)
+	if errors.As(err, &isgErr) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, invalidSignature(isgErr))
+	}
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, internal(signatureVerification, err))
+	}
+
 	metadata := object.Metadata{
 		CurrentBlockID: identifier.Block{
 			Hash: tx.ReferenceBlockID.Hex(),

--- a/api/rosetta/transactor.go
+++ b/api/rosetta/transactor.go
@@ -29,4 +29,5 @@ type Transactor interface {
 	HashPayload(rosBlockID identifier.Block, tx *sdk.Transaction, signer identifier.Account) (payload []byte, err error)
 	ParseTransaction(tx *sdk.Transaction) (operations []object.Operation, signers []identifier.Account, err error)
 	AttachSignature(unsignedTx *sdk.Transaction, signature object.Signature) (tx *sdk.Transaction, err error)
+	VerifySignature(signedTx *sdk.Transaction, signers []identifier.Account) error
 }


### PR DESCRIPTION
Fixes #376.

This PR should be rebased after merging the #382, since it builds on the new retriever functionality to retrieve the account key(s).

## Checklist

- [ ] Is on the right branch
- [ ] ~Documentation is up-to-date~
- [ ] ~Tests are up-to-date~