### PR TITLE
Add tests for Rosetta Construction API

### DIFF
--- a/api/rosetta/transactor.go
+++ b/api/rosetta/transactor.go
@@ -25,7 +25,7 @@ type Transactor interface {
 	DeriveIntent(operations []object.Operation) (intent *transactor.Intent, err error)
 	CompileTransaction(refBlockID identifier.Block, intent *transactor.Intent, sequence uint64) (unsigned string, err error)
 	HashPayload(rosBlockID identifier.Block, unsigned string, signer identifier.Account) (algo string, hash string, err error)
-	ParseTransaction(payload string) (refBlockID identifier.Block, sequence uint64, operations []object.Operation, signers []identifier.Account, err error)
+	Parse(payload string) (transactor.Parser, error)
 	AttachSignatures(unsigned string, signatures []object.Signature) (signed string, err error)
 	TransactionIdentifier(signed string) (rosTxID identifier.Transaction, err error)
 	SubmitTransaction(signed string) (rosTxID identifier.Transaction, err error)

--- a/rosetta/retriever/retriever.go
+++ b/rosetta/retriever/retriever.go
@@ -343,7 +343,7 @@ func (r *Retriever) Sequence(rosBlockID identifier.Block, rosAccountID identifie
 	}
 
 	// Retrieve the key at the height of the given block and for the given
-	// address at index 0.
+	// address at the given index.
 	key, err := r.invoke.Key(height, address, index)
 	if err != nil {
 		return 0, fmt.Errorf("could not retrieve account: %w", err)

--- a/rosetta/retriever/retriever_test.go
+++ b/rosetta/retriever/retriever_test.go
@@ -880,28 +880,34 @@ func TestRetriever_Transaction(t *testing.T) {
 }
 
 func TestRetriever_Sequence(t *testing.T) {
+	rosBlockID := mocks.GenericRosBlockID
+	accountID := mocks.GenericAccountID(0)
+	address := mocks.GenericAddress(0)
+	key := mocks.GenericAccount.Keys[0]
+	header := mocks.GenericHeader
+
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
 		validator := mocks.BaselineValidator(t)
 		validator.BlockFunc = func(blockID identifier.Block) (uint64, flow.Identifier, error) {
-			assert.Equal(t, mocks.GenericRosBlockID, blockID)
+			assert.Equal(t, rosBlockID, blockID)
 
-			return mocks.GenericHeight, flow.ZeroID, nil
+			return header.Height, header.ID(), nil
 		}
-		validator.AccountFunc = func(accountID identifier.Account) (flow.Address, error) {
-			assert.Equal(t, mocks.GenericAccountID(0), accountID)
+		validator.AccountFunc = func(gotAccountID identifier.Account) (flow.Address, error) {
+			assert.Equal(t, accountID, gotAccountID)
 
-			return mocks.GenericAddress(0), nil
+			return address, nil
 		}
 
 		invoker := mocks.BaselineInvoker(t)
-		invoker.KeyFunc = func(height uint64, address flow.Address, index int) (*flow.AccountPublicKey, error) {
-			assert.Equal(t, mocks.GenericHeight, height)
-			assert.Equal(t, mocks.GenericAddress(0), address)
+		invoker.KeyFunc = func(height uint64, gotAddress flow.Address, index int) (*flow.AccountPublicKey, error) {
+			assert.Equal(t, header.Height, height)
+			assert.Equal(t, address, gotAddress)
 			assert.Equal(t, 0, index)
 
-			return &mocks.GenericAccount.Keys[0], nil
+			return &key, nil
 		}
 
 		ret := retriever.New(
@@ -913,10 +919,10 @@ func TestRetriever_Sequence(t *testing.T) {
 			mocks.BaselineConverter(t),
 		)
 
-		seqNum, err := ret.Sequence(mocks.GenericRosBlockID, mocks.GenericAccountID(0), 0)
+		seqNum, err := ret.Sequence(rosBlockID, accountID, 0)
 
-		assert.NoError(t, err)
-		assert.Equal(t, mocks.GenericAccount.Keys[0].SeqNumber, seqNum)
+		require.NoError(t, err)
+		assert.Equal(t, key.SeqNumber, seqNum)
 	})
 
 	t.Run("handles validator failure on block", func(t *testing.T) {
@@ -936,7 +942,7 @@ func TestRetriever_Sequence(t *testing.T) {
 			mocks.BaselineConverter(t),
 		)
 
-		_, err := ret.Sequence(mocks.GenericRosBlockID, mocks.GenericAccountID(0), 0)
+		_, err := ret.Sequence(rosBlockID, accountID, 0)
 
 		assert.Error(t, err)
 	})
@@ -958,7 +964,7 @@ func TestRetriever_Sequence(t *testing.T) {
 			mocks.BaselineConverter(t),
 		)
 
-		_, err := ret.Sequence(mocks.GenericRosBlockID, mocks.GenericAccountID(0), 0)
+		_, err := ret.Sequence(rosBlockID, accountID, 0)
 
 		assert.Error(t, err)
 	})
@@ -980,7 +986,7 @@ func TestRetriever_Sequence(t *testing.T) {
 			mocks.BaselineConverter(t),
 		)
 
-		_, err := ret.Sequence(mocks.GenericRosBlockID, mocks.GenericAccountID(0), 0)
+		_, err := ret.Sequence(rosBlockID, accountID, 0)
 
 		assert.Error(t, err)
 	})

--- a/rosetta/retriever/retriever_test.go
+++ b/rosetta/retriever/retriever_test.go
@@ -181,6 +181,7 @@ func TestRetriever_Balances(t *testing.T) {
 			assert.Equal(t, []byte(`test`), script)
 			require.Len(t, parameters, 1)
 			assert.Equal(t, address, parameters[0])
+
 			return mocks.GenericAmount(0), nil
 		}
 
@@ -470,6 +471,7 @@ func TestRetriever_Block(t *testing.T) {
 		}
 		index.EventsFunc = func(height uint64, types ...flow.EventType) ([]flow.Event, error) {
 			assert.Equal(t, mocks.GenericHeight, height)
+
 			return events, nil
 		}
 		index.EventsFunc = func(height uint64, types ...flow.EventType) ([]flow.Event, error) {
@@ -640,30 +642,6 @@ func TestRetriever_Block(t *testing.T) {
 
 	t.Run("handles event converter failure", func(t *testing.T) {
 		t.Parallel()
-
-		index := mocks.BaselineReader(t)
-		index.HeaderFunc = func(height uint64) (*flow.Header, error) {
-			assert.Equal(t, mocks.GenericHeight, height)
-			return mocks.GenericHeader, nil
-		}
-		index.TransactionsByHeightFunc = func(height uint64) ([]flow.Identifier, error) {
-			assert.Equal(t, mocks.GenericHeight, height)
-			return mocks.GenericTransactionIDs(6), nil
-		}
-		validator := mocks.BaselineValidator(t)
-		validator.BlockFunc = func(rosBlockID identifier.Block) (uint64, flow.Identifier, error) {
-			assert.Equal(t, mocks.GenericRosBlockID, rosBlockID)
-			return mocks.GenericHeader.Height, mocks.GenericHeader.ID(), nil
-		}
-		generator := mocks.BaselineGenerator(t)
-		generator.TokensDepositedFunc = func(symbol string) (string, error) {
-			assert.Equal(t, symbol, dps.FlowSymbol)
-			return string(mocks.GenericEventType(0)), nil
-		}
-		generator.TokensWithdrawnFunc = func(symbol string) (string, error) {
-			assert.Equal(t, symbol, dps.FlowSymbol)
-			return string(mocks.GenericEventType(1)), nil
-		}
 		convert := mocks.BaselineConverter(t)
 		convert.EventToOperationFunc = func(flow.Event) (*object.Operation, error) {
 			return nil, mocks.GenericError

--- a/rosetta/transactor/parser.go
+++ b/rosetta/transactor/parser.go
@@ -1,0 +1,286 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package transactor
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+
+	cjson "github.com/onflow/cadence/encoding/json"
+	sdk "github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/crypto"
+	"github.com/onflow/flow-go/model/flow"
+
+	"github.com/optakt/flow-dps/models/dps"
+	"github.com/optakt/flow-dps/rosetta/failure"
+	"github.com/optakt/flow-dps/rosetta/identifier"
+	"github.com/optakt/flow-dps/rosetta/object"
+)
+
+type TransactionParser struct {
+	tx       *sdk.Transaction
+	validate Validator
+	generate Generator
+	invoke   Invoker
+}
+
+func (p *TransactionParser) BlockID() (identifier.Block, error) {
+	// Validate the reference block identifier.
+	refBlockID := identifier.Block{
+		Hash: p.tx.ReferenceBlockID.String(),
+	}
+
+	height, blockID, err := p.validate.Block(refBlockID)
+	if err != nil {
+		return identifier.Block{}, fmt.Errorf("invalid reference block: %w", err)
+	}
+
+	return rosettaBlockID(height, blockID), nil
+}
+
+func (p *TransactionParser) Sequence() uint64 {
+	return p.tx.ProposalKey.SequenceNumber
+}
+
+func (p *TransactionParser) Signers() ([]identifier.Account, error) {
+	// Since we only support sender as the payer/proposer, we never expect any payload signatures.
+	if len(p.tx.PayloadSignatures) > 0 {
+		return nil, failure.InvalidSignature{
+			Description: failure.NewDescription("unexpected payload signature found",
+				failure.WithInt("signatures", len(p.tx.PayloadSignatures))),
+		}
+	}
+
+	// We may be parsing an unsigned transaction - if that's the case, we're done.
+	if len(p.tx.EnvelopeSignatures) == 0 {
+		return nil, nil
+	}
+
+	// We don't support multiple signatures.
+	if len(p.tx.EnvelopeSignatures) > 1 {
+		return nil, failure.InvalidSignature{
+			Description: failure.NewDescription("unexpected number of envelope signatures",
+				failure.WithInt("signatures", len(p.tx.EnvelopeSignatures))),
+		}
+	}
+
+	// Validate that it is the sender who signed the transaction.
+	signer := p.tx.EnvelopeSignatures[0].Address
+	authorizer := p.tx.Authorizers[0]
+	if signer != authorizer {
+		return nil, failure.InvalidSignature{
+			Description: failure.NewDescription("invalid signer account",
+				failure.WithString("have_signer", signer.String()),
+				failure.WithString("want_signer", authorizer.String()),
+				failure.WithString("signature", hex.EncodeToString(p.tx.EnvelopeSignatures[0].Signature))),
+		}
+	}
+
+	// Check that the signature is valid.
+	address := flow.BytesToAddress(signer[:])
+
+	rosBlockID := identifier.Block{Hash: p.tx.ReferenceBlockID.Hex()}
+	height, _, err := p.validate.Block(rosBlockID)
+	if err != nil {
+		return nil, fmt.Errorf("could not validate block: %w", err)
+	}
+
+	key, err := p.invoke.Key(height, address, 0)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve key: %w", err)
+	}
+
+	// NOTE: signature verification is ported from the DefaultSignatureVerifier
+	// => https://github.com/onflow/flow-go/blob/master/fvm/crypto/crypto.go
+	hasher, err := crypto.NewHasher(key.HashAlgo)
+	if err != nil {
+		return nil, fmt.Errorf("could not get new hasher: %w", err)
+	}
+
+	message := p.tx.EnvelopeMessage()
+	message = append(sdk.TransactionDomainTag[:], message...)
+
+	signature := p.tx.EnvelopeSignatures[0].Signature
+
+	valid, err := key.PublicKey.Verify(signature, message, hasher)
+	if err != nil {
+		return nil, fmt.Errorf("could not verify transaction signature: %w", err)
+	}
+	if !valid {
+		return nil, failure.InvalidSignature{
+			Description: failure.NewDescription("provided signature is not valid",
+				failure.WithString("signature", hex.EncodeToString(signature))),
+		}
+	}
+
+	sender := identifier.Account{
+		Address: authorizer.String(),
+	}
+
+	// Validate the sender address.
+	_, err = p.validate.Account(sender)
+	if err != nil {
+		return nil, fmt.Errorf("invalid sender account: %w", err)
+	}
+
+	// Create the signers list.
+	signers := []identifier.Account{
+		sender,
+	}
+
+	return signers, nil
+}
+
+func (p *TransactionParser) Operations() ([]object.Operation, error) {
+	// Validate the transaction actors. We expect a single authorizer - the sender account.
+	// For now, the sender must also be the proposer and the payer for the transaction.
+	if len(p.tx.Authorizers) != requiredAuthorizers {
+		return nil, failure.InvalidAuthorizers{
+			Have:        uint(len(p.tx.Authorizers)),
+			Want:        requiredAuthorizers,
+			Description: failure.NewDescription("invalid number of authorizers"),
+		}
+	}
+
+	authorizer := p.tx.Authorizers[0]
+	sender := identifier.Account{
+		Address: authorizer.String(),
+	}
+
+	// Validate the sender address.
+	_, err := p.validate.Account(sender)
+	if err != nil {
+		return nil, fmt.Errorf("invalid sender account: %w", err)
+	}
+
+	// Verify that the sender is the payer and the proposer.
+	if p.tx.Payer != authorizer {
+		return nil, failure.InvalidPayer{
+			Have:        flow.BytesToAddress(p.tx.Payer[:]),
+			Want:        flow.BytesToAddress(authorizer[:]),
+			Description: failure.NewDescription("invalid transaction payer"),
+		}
+	}
+	if p.tx.ProposalKey.Address != authorizer {
+		return nil, failure.InvalidProposer{
+			Have:        flow.BytesToAddress(p.tx.ProposalKey.Address[:]),
+			Want:        flow.BytesToAddress(authorizer[:]),
+			Description: failure.NewDescription("invalid transaction proposer"),
+		}
+	}
+
+	// Verify the transaction script is the token transfer script.
+	script, err := p.generate.TransferTokens(dps.FlowSymbol)
+	if err != nil {
+		return nil, fmt.Errorf("could not generate transfer script: %w", err)
+	}
+	if !bytes.Equal(script, p.tx.Script) {
+		return nil, failure.InvalidScript{
+			Script:      string(p.tx.Script),
+			Description: failure.NewDescription("transaction text is not valid token transfer script"),
+		}
+	}
+
+	// Verify that the transaction script has the correct number of arguments.
+	args := p.tx.Arguments
+	if len(args) != requiredArguments {
+		return nil, failure.InvalidArguments{
+			Have:        uint(len(args)),
+			Want:        requiredArguments,
+			Description: failure.NewDescription("invalid number of arguments"),
+		}
+	}
+
+	// Parse and validate the amount argument.
+	val, err := cjson.Decode(args[0])
+	if err != nil {
+		return nil, failure.InvalidAmount{
+			Amount: string(args[0]),
+			Description: failure.NewDescription("could not parse transaction amount",
+				failure.WithErr(err)),
+		}
+	}
+	amountArg, ok := val.ToGoValue().(uint64)
+	if !ok {
+		return nil, failure.InvalidAmount{
+			Amount:      string(args[0]),
+			Description: failure.NewDescription("invalid amount"),
+		}
+	}
+	amount := strconv.FormatUint(amountArg, 10)
+
+	// Parse and validate receiver script argument.
+	val, err = cjson.Decode(args[1])
+	if err != nil {
+		return nil, failure.InvalidReceiver{
+			Receiver: string(args[1]),
+			Description: failure.NewDescription("could not parse transaction receiver address",
+				failure.WithErr(err)),
+		}
+	}
+	addr := flow.HexToAddress(val.String())
+	receiver := identifier.Account{
+		Address: addr.String(),
+	}
+	_, err = p.validate.Account(receiver)
+	if err != nil {
+		return nil, fmt.Errorf("invalid receiver account: %w", err)
+	}
+
+	// Create the send operation.
+	sendOp := object.Operation{
+		ID: identifier.Operation{
+			Index:        0,
+			NetworkIndex: nil, // optional, omitted for now
+		},
+		AccountID: sender,
+		Type:      dps.OperationTransfer,
+		Amount: object.Amount{
+			Value: "-" + amount,
+			Currency: identifier.Currency{
+				Symbol:   dps.FlowSymbol,
+				Decimals: dps.FlowDecimals,
+			},
+		},
+		Status: "", // must NOT be set for non-submitted transactions
+	}
+
+	// Create the receive operation.
+	receiveOp := object.Operation{
+		ID: identifier.Operation{
+			Index:        1,
+			NetworkIndex: nil, // optional, omitted for now
+		},
+		AccountID: receiver,
+		Type:      dps.OperationTransfer,
+		Amount: object.Amount{
+			Value: amount,
+			Currency: identifier.Currency{
+				Symbol:   dps.FlowSymbol,
+				Decimals: dps.FlowDecimals,
+			},
+		},
+		Status: "", // must NOT be set for non-submitted transactions
+	}
+
+	ops := []object.Operation{
+		sendOp,
+		receiveOp,
+	}
+
+	return ops, nil
+}

--- a/rosetta/transactor/parser_internal_test.go
+++ b/rosetta/transactor/parser_internal_test.go
@@ -37,25 +37,25 @@ func BaselineTransactionParser(t *testing.T, opts ...func(parser *TransactionPar
 	return &p
 }
 
-func ParseTransaction(tx *sdk.Transaction) func(*TransactionParser) {
+func InjectTransaction(tx *sdk.Transaction) func(*TransactionParser) {
 	return func(parser *TransactionParser) {
 		parser.tx = tx
 	}
 }
 
-func ParseValidator(validate Validator) func(*TransactionParser) {
+func InjectValidator(validate Validator) func(*TransactionParser) {
 	return func(parser *TransactionParser) {
 		parser.validate = validate
 	}
 }
 
-func ParseGenerator(generate Generator) func(*TransactionParser) {
+func InjectGenerator(generate Generator) func(*TransactionParser) {
 	return func(parser *TransactionParser) {
 		parser.generate = generate
 	}
 }
 
-func ParseInvoker(invoke Invoker) func(*TransactionParser) {
+func InjectInvoker(invoke Invoker) func(*TransactionParser) {
 	return func(parser *TransactionParser) {
 		parser.invoke = invoke
 	}

--- a/rosetta/transactor/parser_internal_test.go
+++ b/rosetta/transactor/parser_internal_test.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package transactor
+
+import (
+	"testing"
+
+	sdk "github.com/onflow/flow-go-sdk"
+	"github.com/optakt/flow-dps/testing/mocks"
+)
+
+func BaselineTransactionParser(t *testing.T, opts ...func(parser *TransactionParser)) *TransactionParser {
+	p := TransactionParser{
+		tx:       sdk.NewTransaction(),
+		validate: mocks.BaselineValidator(t),
+		generate: mocks.BaselineGenerator(t),
+		invoke:   mocks.BaselineInvoker(t),
+	}
+
+	for _, opt := range opts {
+		opt(&p)
+	}
+
+	return &p
+}
+
+// FIXME: The naming of those funcs conflict with the transactor's, since they have the same dependencies :(
+//        How can we name this in a consistent way that makes sense?
+func ParseTransaction(tx *sdk.Transaction) func(*TransactionParser) {
+	return func(parser *TransactionParser) {
+		parser.tx = tx
+	}
+}
+
+func ParseValidator(validate Validator) func(*TransactionParser) {
+	return func(parser *TransactionParser) {
+		parser.validate = validate
+	}
+}
+
+func ParseGenerator(generate Generator) func(*TransactionParser) {
+	return func(parser *TransactionParser) {
+		parser.generate = generate
+	}
+}
+
+func ParseInvoker(invoke Invoker) func(*TransactionParser) {
+	return func(parser *TransactionParser) {
+		parser.invoke = invoke
+	}
+}

--- a/rosetta/transactor/parser_internal_test.go
+++ b/rosetta/transactor/parser_internal_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	sdk "github.com/onflow/flow-go-sdk"
+
 	"github.com/optakt/flow-dps/testing/mocks"
 )
 
@@ -36,8 +37,6 @@ func BaselineTransactionParser(t *testing.T, opts ...func(parser *TransactionPar
 	return &p
 }
 
-// FIXME: The naming of those funcs conflict with the transactor's, since they have the same dependencies :(
-//        How can we name this in a consistent way that makes sense?
 func ParseTransaction(tx *sdk.Transaction) func(*TransactionParser) {
 	return func(parser *TransactionParser) {
 		parser.tx = tx

--- a/rosetta/transactor/parser_test.go
+++ b/rosetta/transactor/parser_test.go
@@ -1,0 +1,613 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package transactor_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	cjson "github.com/onflow/cadence/encoding/json"
+	sdk "github.com/onflow/flow-go-sdk"
+	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
+	"github.com/onflow/flow-go/crypto"
+	chash "github.com/onflow/flow-go/crypto/hash"
+	"github.com/onflow/flow-go/model/flow"
+
+	"github.com/optakt/flow-dps/rosetta/failure"
+	"github.com/optakt/flow-dps/rosetta/identifier"
+	"github.com/optakt/flow-dps/rosetta/transactor"
+	"github.com/optakt/flow-dps/testing/mocks"
+)
+
+func TestTransactionParser_BlockID(t *testing.T) {
+	header := mocks.GenericHeader
+	blockID := header.ID()
+	index := uint64(84)
+
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			ReferenceBlockID: sdk.HashToID(blockID[:]),
+		}
+
+		validator := mocks.BaselineValidator(t)
+		validator.BlockFunc = func(rosBlockID identifier.Block) (uint64, flow.Identifier, error) {
+			assert.Equal(t, tx.ReferenceBlockID.String(), rosBlockID.Hash)
+
+			return index, blockID, nil
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+			transactor.ParseValidator(validator),
+		)
+
+		got, err := p.BlockID()
+
+		require.NoError(t, err)
+		assert.Equal(t, tx.ReferenceBlockID.String(), got.Hash)
+		assert.Equal(t, index, *got.Index)
+	})
+
+	t.Run("handles invalid block data", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			ReferenceBlockID: sdk.HashToID(blockID[:]),
+		}
+
+		validator := mocks.BaselineValidator(t)
+		validator.BlockFunc = func(identifier.Block) (uint64, flow.Identifier, error) {
+			return 0, flow.ZeroID, mocks.GenericError
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+			transactor.ParseValidator(validator),
+		)
+
+		_, err := p.BlockID()
+
+		assert.Error(t, err)
+	})
+}
+
+func TestTransactionParser_Sequence(t *testing.T) {
+	tx := &sdk.Transaction{
+		ProposalKey: sdk.ProposalKey{SequenceNumber: 42},
+	}
+
+	p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx))
+
+	got := p.Sequence()
+
+	assert.Equal(t, tx.ProposalKey.SequenceNumber, got)
+}
+
+func TestTransactionParser_Signers(t *testing.T) {
+	header := mocks.GenericHeader
+	blockID := header.ID()
+
+	key, err := generateKey()
+	require.NoError(t, err)
+
+	// We need to specify a weight of 1000 because otherwise multiple public keys would be required, as
+	// the total required weight for an account's signature to be considered valid has to be equal to 1000.
+	// For some reason this 1000 magic number is not exposed anywhere that I could find in Flow.
+	pubKey := key.PublicKey(1000)
+
+	senderID := mocks.GenericAccountID(0)
+	senderAddr := mocks.GenericAddress(0)
+	sender := sdk.HexToAddress(senderAddr.Hex())
+	receiver := sdk.HexToAddress(mocks.GenericAddress(1).Hex())
+	signature := sdk.TransactionSignature{
+		Address:     sender,
+		SignerIndex: 64,
+		KeyIndex:    128,
+	}
+
+	invoker := mocks.BaselineInvoker(t)
+	invoker.KeyFunc = func(height uint64, address flow.Address, index int) (*flow.AccountPublicKey, error) {
+		return &pubKey, nil
+	}
+
+	tx := &sdk.Transaction{
+		ReferenceBlockID:   sdk.HashToID(blockID[:]),
+		Authorizers:        []sdk.Address{sender},
+		EnvelopeSignatures: []sdk.TransactionSignature{signature},
+	}
+
+	signer := sdkcrypto.NewInMemorySigner(key.PrivateKey, key.HashAlgo)
+	message := tx.EnvelopeMessage()
+	message = append(sdk.TransactionDomainTag[:], message...)
+
+	sig, err := signer.Sign(message)
+	require.NoError(t, err)
+
+	tx.EnvelopeSignatures[0].Signature = sig
+
+	t.Run("nominal case with unsigned transaction", func(t *testing.T) {
+		t.Parallel()
+
+		p := transactor.BaselineTransactionParser(t,
+			transactor.ParseTransaction(sdk.NewTransaction()),
+			transactor.ParseInvoker(invoker),
+		)
+
+		got, err := p.Signers()
+
+		require.NoError(t, err)
+		assert.Zero(t, got)
+	})
+
+	t.Run("nominal case with signed transaction", func(t *testing.T) {
+		t.Parallel()
+
+		invoker := mocks.BaselineInvoker(t)
+		invoker.KeyFunc = func(height uint64, address flow.Address, index int) (*flow.AccountPublicKey, error) {
+			assert.Equal(t, header.Height, height)
+			assert.Equal(t, senderAddr, address)
+			assert.Zero(t, index)
+
+			return &pubKey, nil
+		}
+
+		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx), transactor.ParseInvoker(invoker))
+
+		got, err := p.Signers()
+
+		require.NoError(t, err)
+		assert.Len(t, got, 1)
+		assert.Equal(t, senderID, got[0])
+	})
+
+	t.Run("handles case where transaction contains a payload signature (which it should not)", func(t *testing.T) {
+		t.Parallel()
+
+		// Copy the valid transaction and only add a payload signature to it to trigger a failure.
+
+		tx := &sdk.Transaction{
+			ReferenceBlockID:   sdk.HashToID(blockID[:]),
+			Authorizers:        []sdk.Address{sender},
+			EnvelopeSignatures: []sdk.TransactionSignature{signature},
+			PayloadSignatures:  []sdk.TransactionSignature{signature},
+		}
+
+		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx), transactor.ParseInvoker(invoker))
+
+		_, err := p.Signers()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidSignature{})
+	})
+
+	t.Run("handles case where there are multiple envelope signatures", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			ReferenceBlockID:   sdk.HashToID(blockID[:]),
+			Authorizers:        []sdk.Address{sender},
+			EnvelopeSignatures: []sdk.TransactionSignature{signature, signature, signature},
+		}
+
+		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx), transactor.ParseInvoker(invoker))
+
+		_, err := p.Signers()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidSignature{})
+	})
+
+	t.Run("handles case where transaction signer is not the sender", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			ReferenceBlockID:   sdk.HashToID(blockID[:]),
+			Authorizers:        []sdk.Address{receiver},
+			EnvelopeSignatures: []sdk.TransactionSignature{signature},
+		}
+
+		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx), transactor.ParseInvoker(invoker))
+
+		_, err := p.Signers()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidSignature{})
+	})
+
+	t.Run("handles case where transaction has invalid block ID", func(t *testing.T) {
+		t.Parallel()
+
+		validator := mocks.BaselineValidator(t)
+		validator.BlockFunc = func(identifier.Block) (uint64, flow.Identifier, error) {
+			return 0, flow.ZeroID, mocks.GenericError
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+			transactor.ParseValidator(validator),
+			transactor.ParseInvoker(invoker),
+		)
+
+		_, err := p.Signers()
+
+		assert.Error(t, err)
+	})
+
+	t.Run("handles invoker failure on Key", func(t *testing.T) {
+		t.Parallel()
+
+		invoker := mocks.BaselineInvoker(t)
+		invoker.KeyFunc = func(uint64, flow.Address, int) (*flow.AccountPublicKey, error) {
+			return nil, mocks.GenericError
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+			transactor.ParseInvoker(invoker),
+		)
+
+		_, err := p.Signers()
+
+		assert.Error(t, err)
+	})
+
+	t.Run("handles signature and key mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		invoker := mocks.BaselineInvoker(t)
+		invoker.KeyFunc = func(uint64, flow.Address, int) (*flow.AccountPublicKey, error) {
+			// This is not the signature that was used to sign the data in the envelope, so
+			// the verification should fail.
+			mockSignature := mocks.GenericAccount.Keys[0]
+
+			return &mockSignature, nil
+		}
+
+		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx), transactor.ParseInvoker(invoker))
+
+		_, err := p.Signers()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidSignature{})
+	})
+
+	t.Run("handles invalid sender account", func(t *testing.T) {
+		t.Parallel()
+
+		validator := mocks.BaselineValidator(t)
+		validator.AccountFunc = func(identifier.Account) (flow.Address, error) {
+			return flow.EmptyAddress, mocks.GenericError
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+			transactor.ParseInvoker(invoker),
+			transactor.ParseValidator(validator),
+		)
+
+		_, err := p.Signers()
+
+		assert.Error(t, err)
+	})
+}
+
+func TestTransactionParser_Operations(t *testing.T) {
+	sender := sdk.HexToAddress(mocks.GenericAddress(0).Hex())
+	receiverAddr := mocks.GenericAddress(1)
+	receiver := sdk.HexToAddress(receiverAddr.Hex())
+
+	amount := mocks.GenericAmount(0)
+	amountData, err := cjson.Encode(amount)
+	require.NoError(t, err)
+
+	cadenceAddr := cadence.BytesToAddress(receiverAddr.Bytes())
+	addressData, err := cjson.Encode(cadenceAddr)
+	require.NoError(t, err)
+
+	tx := &sdk.Transaction{
+		Payer:       sender,
+		ProposalKey: sdk.ProposalKey{Address: sender},
+		Authorizers: []sdk.Address{sender},
+		Script:      mocks.GenericBytes,
+		Arguments:   [][]byte{amountData, addressData},
+	}
+
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx))
+
+		got, err := p.Operations()
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, got)
+	})
+
+	t.Run("handles invalid number of authorizers", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			Authorizers: []sdk.Address{sender, receiver, sender},
+		}
+
+		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx))
+
+		_, err := p.Operations()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidAuthorizers{})
+	})
+
+	t.Run("handles invalid authorizer account", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			Authorizers: []sdk.Address{sender},
+		}
+
+		validator := mocks.BaselineValidator(t)
+		validator.AccountFunc = func(identifier.Account) (flow.Address, error) {
+			return flow.EmptyAddress, mocks.GenericError
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+			transactor.ParseValidator(validator),
+		)
+
+		_, err := p.Operations()
+
+		assert.Error(t, err)
+	})
+
+	t.Run("handles mismatch between authorizer and payer", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			Payer:       receiver,
+			Authorizers: []sdk.Address{sender},
+		}
+
+		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx))
+
+		_, err := p.Operations()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidPayer{})
+	})
+
+	t.Run("handles mismatch between proposal key address and payer", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			Payer:       sender,
+			ProposalKey: sdk.ProposalKey{Address: receiver},
+			Authorizers: []sdk.Address{sender},
+		}
+
+		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx))
+
+		_, err := p.Operations()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidProposer{})
+	})
+
+	t.Run("handles transfer token generation failure", func(t *testing.T) {
+		t.Parallel()
+
+		generator := mocks.BaselineGenerator(t)
+		generator.TransferTokensFunc = func(string) ([]byte, error) {
+			return nil, mocks.GenericError
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+			transactor.ParseGenerator(generator),
+		)
+
+		_, err := p.Operations()
+
+		assert.Error(t, err)
+	})
+
+	t.Run("handles transfer token script mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		generator := mocks.BaselineGenerator(t)
+		generator.TransferTokensFunc = func(string) ([]byte, error) {
+			return []byte{}, nil
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+			transactor.ParseGenerator(generator),
+		)
+
+		_, err := p.Operations()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidScript{})
+	})
+
+	t.Run("handles invalid number of arguments (0)", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			Payer:       sender,
+			ProposalKey: sdk.ProposalKey{Address: sender},
+			Authorizers: []sdk.Address{sender},
+			Script:      mocks.GenericBytes,
+			Arguments:   [][]byte{}, // No argument.
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+		)
+
+		_, err := p.Operations()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidArguments{})
+	})
+
+	t.Run("handles invalid number of arguments (<)", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			Payer:       sender,
+			ProposalKey: sdk.ProposalKey{Address: sender},
+			Authorizers: []sdk.Address{sender},
+			Script:      mocks.GenericBytes,
+			Arguments:   [][]byte{amountData}, // Only one argument.
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+		)
+
+		_, err := p.Operations()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidArguments{})
+	})
+
+	t.Run("handles invalid number of arguments (>)", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			Payer:       sender,
+			ProposalKey: sdk.ProposalKey{Address: sender},
+			Authorizers: []sdk.Address{sender},
+			Script:      mocks.GenericBytes,
+			Arguments:   [][]byte{amountData, addressData, amountData}, // Three arguments.
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+		)
+
+		_, err := p.Operations()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidArguments{})
+	})
+
+	t.Run("handles invalid amount argument (not a uint)", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			Payer:       sender,
+			ProposalKey: sdk.ProposalKey{Address: sender},
+			Authorizers: []sdk.Address{sender},
+			Script:      mocks.GenericBytes,
+			Arguments:   [][]byte{addressData, addressData}, // First argument is not an uint.
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+		)
+
+		_, err := p.Operations()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidAmount{})
+	})
+
+	t.Run("handles invalid amount argument (not json-encoded)", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			Payer:       sender,
+			ProposalKey: sdk.ProposalKey{Address: sender},
+			Authorizers: []sdk.Address{sender},
+			Script:      mocks.GenericBytes,
+			Arguments:   [][]byte{mocks.GenericBytes, addressData}, // First argument is not json-encoded.
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+		)
+
+		_, err := p.Operations()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidAmount{})
+	})
+
+	t.Run("handles invalid address argument (not json-encoded)", func(t *testing.T) {
+		t.Parallel()
+
+		tx := &sdk.Transaction{
+			Payer:       sender,
+			ProposalKey: sdk.ProposalKey{Address: sender},
+			Authorizers: []sdk.Address{sender},
+			Script:      mocks.GenericBytes,
+			Arguments:   [][]byte{amountData, mocks.GenericBytes}, // Second argument is not json-encoded.
+		}
+
+		p := transactor.BaselineTransactionParser(
+			t,
+			transactor.ParseTransaction(tx),
+		)
+
+		_, err := p.Operations()
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidReceiver{})
+	})
+}
+
+func generateKey() (*flow.AccountPrivateKey, error) {
+	seed := make([]byte, crypto.KeyGenSeedMaxLenECDSA)
+
+	_, err := rand.Read(seed)
+	if err != nil {
+		return nil, err
+	}
+
+	signAlgo := crypto.ECDSAP256
+	hashAlgo := chash.SHA3_256
+
+	key, err := crypto.GeneratePrivateKey(signAlgo, seed)
+	if err != nil {
+		return nil, err
+	}
+
+	return &flow.AccountPrivateKey{
+		PrivateKey: key,
+		SignAlgo:   key.Algorithm(),
+		HashAlgo:   hashAlgo,
+	}, nil
+}

--- a/rosetta/transactor/parser_test.go
+++ b/rosetta/transactor/parser_test.go
@@ -56,8 +56,8 @@ func TestTransactionParser_BlockID(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
-			transactor.ParseValidator(validator),
+			transactor.InjectTransaction(tx),
+			transactor.InjectValidator(validator),
 		)
 
 		got, err := p.BlockID()
@@ -81,8 +81,8 @@ func TestTransactionParser_BlockID(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
-			transactor.ParseValidator(validator),
+			transactor.InjectTransaction(tx),
+			transactor.InjectValidator(validator),
 		)
 
 		_, err := p.BlockID()
@@ -96,7 +96,7 @@ func TestTransactionParser_Sequence(t *testing.T) {
 		ProposalKey: sdk.ProposalKey{SequenceNumber: 42},
 	}
 
-	p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx))
+	p := transactor.BaselineTransactionParser(t, transactor.InjectTransaction(tx))
 
 	got := p.Sequence()
 
@@ -149,8 +149,8 @@ func TestTransactionParser_Signers(t *testing.T) {
 		t.Parallel()
 
 		p := transactor.BaselineTransactionParser(t,
-			transactor.ParseTransaction(sdk.NewTransaction()),
-			transactor.ParseInvoker(invoker),
+			transactor.InjectTransaction(sdk.NewTransaction()),
+			transactor.InjectInvoker(invoker),
 		)
 
 		got, err := p.Signers()
@@ -171,7 +171,7 @@ func TestTransactionParser_Signers(t *testing.T) {
 			return &pubKey, nil
 		}
 
-		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx), transactor.ParseInvoker(invoker))
+		p := transactor.BaselineTransactionParser(t, transactor.InjectTransaction(tx), transactor.InjectInvoker(invoker))
 
 		got, err := p.Signers()
 
@@ -192,7 +192,7 @@ func TestTransactionParser_Signers(t *testing.T) {
 			PayloadSignatures:  []sdk.TransactionSignature{signature},
 		}
 
-		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx), transactor.ParseInvoker(invoker))
+		p := transactor.BaselineTransactionParser(t, transactor.InjectTransaction(tx), transactor.InjectInvoker(invoker))
 
 		_, err := p.Signers()
 
@@ -209,7 +209,7 @@ func TestTransactionParser_Signers(t *testing.T) {
 			EnvelopeSignatures: []sdk.TransactionSignature{signature, signature, signature},
 		}
 
-		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx), transactor.ParseInvoker(invoker))
+		p := transactor.BaselineTransactionParser(t, transactor.InjectTransaction(tx), transactor.InjectInvoker(invoker))
 
 		_, err := p.Signers()
 
@@ -226,7 +226,7 @@ func TestTransactionParser_Signers(t *testing.T) {
 			EnvelopeSignatures: []sdk.TransactionSignature{signature},
 		}
 
-		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx), transactor.ParseInvoker(invoker))
+		p := transactor.BaselineTransactionParser(t, transactor.InjectTransaction(tx), transactor.InjectInvoker(invoker))
 
 		_, err := p.Signers()
 
@@ -244,9 +244,9 @@ func TestTransactionParser_Signers(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
-			transactor.ParseValidator(validator),
-			transactor.ParseInvoker(invoker),
+			transactor.InjectTransaction(tx),
+			transactor.InjectValidator(validator),
+			transactor.InjectInvoker(invoker),
 		)
 
 		_, err := p.Signers()
@@ -264,8 +264,8 @@ func TestTransactionParser_Signers(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
-			transactor.ParseInvoker(invoker),
+			transactor.InjectTransaction(tx),
+			transactor.InjectInvoker(invoker),
 		)
 
 		_, err := p.Signers()
@@ -285,7 +285,7 @@ func TestTransactionParser_Signers(t *testing.T) {
 			return &mockSignature, nil
 		}
 
-		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx), transactor.ParseInvoker(invoker))
+		p := transactor.BaselineTransactionParser(t, transactor.InjectTransaction(tx), transactor.InjectInvoker(invoker))
 
 		_, err := p.Signers()
 
@@ -303,9 +303,9 @@ func TestTransactionParser_Signers(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
-			transactor.ParseInvoker(invoker),
-			transactor.ParseValidator(validator),
+			transactor.InjectTransaction(tx),
+			transactor.InjectInvoker(invoker),
+			transactor.InjectValidator(validator),
 		)
 
 		_, err := p.Signers()
@@ -338,7 +338,7 @@ func TestTransactionParser_Operations(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
-		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx))
+		p := transactor.BaselineTransactionParser(t, transactor.InjectTransaction(tx))
 
 		got, err := p.Operations()
 
@@ -353,7 +353,7 @@ func TestTransactionParser_Operations(t *testing.T) {
 			Authorizers: []sdk.Address{sender, receiver, sender},
 		}
 
-		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx))
+		p := transactor.BaselineTransactionParser(t, transactor.InjectTransaction(tx))
 
 		_, err := p.Operations()
 
@@ -375,8 +375,8 @@ func TestTransactionParser_Operations(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
-			transactor.ParseValidator(validator),
+			transactor.InjectTransaction(tx),
+			transactor.InjectValidator(validator),
 		)
 
 		_, err := p.Operations()
@@ -392,7 +392,7 @@ func TestTransactionParser_Operations(t *testing.T) {
 			Authorizers: []sdk.Address{sender},
 		}
 
-		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx))
+		p := transactor.BaselineTransactionParser(t, transactor.InjectTransaction(tx))
 
 		_, err := p.Operations()
 
@@ -409,7 +409,7 @@ func TestTransactionParser_Operations(t *testing.T) {
 			Authorizers: []sdk.Address{sender},
 		}
 
-		p := transactor.BaselineTransactionParser(t, transactor.ParseTransaction(tx))
+		p := transactor.BaselineTransactionParser(t, transactor.InjectTransaction(tx))
 
 		_, err := p.Operations()
 
@@ -427,8 +427,8 @@ func TestTransactionParser_Operations(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
-			transactor.ParseGenerator(generator),
+			transactor.InjectTransaction(tx),
+			transactor.InjectGenerator(generator),
 		)
 
 		_, err := p.Operations()
@@ -446,8 +446,8 @@ func TestTransactionParser_Operations(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
-			transactor.ParseGenerator(generator),
+			transactor.InjectTransaction(tx),
+			transactor.InjectGenerator(generator),
 		)
 
 		_, err := p.Operations()
@@ -469,7 +469,7 @@ func TestTransactionParser_Operations(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
+			transactor.InjectTransaction(tx),
 		)
 
 		_, err := p.Operations()
@@ -491,7 +491,7 @@ func TestTransactionParser_Operations(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
+			transactor.InjectTransaction(tx),
 		)
 
 		_, err := p.Operations()
@@ -513,7 +513,7 @@ func TestTransactionParser_Operations(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
+			transactor.InjectTransaction(tx),
 		)
 
 		_, err := p.Operations()
@@ -535,7 +535,7 @@ func TestTransactionParser_Operations(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
+			transactor.InjectTransaction(tx),
 		)
 
 		_, err := p.Operations()
@@ -557,7 +557,7 @@ func TestTransactionParser_Operations(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
+			transactor.InjectTransaction(tx),
 		)
 
 		_, err := p.Operations()
@@ -579,7 +579,7 @@ func TestTransactionParser_Operations(t *testing.T) {
 
 		p := transactor.BaselineTransactionParser(
 			t,
-			transactor.ParseTransaction(tx),
+			transactor.InjectTransaction(tx),
 		)
 
 		_, err := p.Operations()

--- a/rosetta/transactor/transactor.go
+++ b/rosetta/transactor/transactor.go
@@ -416,6 +416,4 @@ func (t *Transactor) Parse(payload string) (Parser, error) {
 	}
 
 	return &p, nil
-
-	return nil, err
 }

--- a/rosetta/transactor/transactor_internal_test.go
+++ b/rosetta/transactor/transactor_internal_test.go
@@ -1,0 +1,64 @@
+package transactor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/optakt/flow-dps/testing/mocks"
+)
+
+func TestNew(t *testing.T) {
+	validate := mocks.BaselineValidator(t)
+	generate := mocks.BaselineGenerator(t)
+	invoke := mocks.BaselineInvoker(t)
+	submit := mocks.BaselineSubmitter(t)
+
+	tr := New(validate, generate, invoke, submit)
+
+	assert.Equal(t, validate, tr.validate)
+	assert.Equal(t, generate, tr.generate)
+	assert.Equal(t, invoke, tr.invoke)
+	assert.Equal(t, submit, tr.submit)
+}
+
+func BaselineTransactor(t *testing.T, opts ...func(*Transactor)) *Transactor {
+	t.Helper()
+
+	tr := Transactor{
+		validate: mocks.BaselineValidator(t),
+		generate: mocks.BaselineGenerator(t),
+		invoke:   mocks.BaselineInvoker(t),
+		submit:   mocks.BaselineSubmitter(t),
+	}
+
+	for _, opt := range opts {
+		opt(&tr)
+	}
+
+	return &tr
+}
+
+func WithValidator(validator Validator) func(*Transactor) {
+	return func(transactor *Transactor) {
+		transactor.validate = validator
+	}
+}
+
+func WithGenerator(generator Generator) func(*Transactor) {
+	return func(transactor *Transactor) {
+		transactor.generate = generator
+	}
+}
+
+func WithInvoker(invoker Invoker) func(*Transactor) {
+	return func(transactor *Transactor) {
+		transactor.invoke = invoker
+	}
+}
+
+func WithSubmitter(submitter Submitter) func(*Transactor) {
+	return func(transactor *Transactor) {
+		transactor.submit = submitter
+	}
+}

--- a/rosetta/transactor/transactor_test.go
+++ b/rosetta/transactor/transactor_test.go
@@ -27,11 +27,11 @@ import (
 	"github.com/onflow/cadence"
 	sdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/optakt/flow-dps/models/dps"
-	"github.com/optakt/flow-dps/rosetta/object"
 
+	"github.com/optakt/flow-dps/models/dps"
 	"github.com/optakt/flow-dps/rosetta/failure"
 	"github.com/optakt/flow-dps/rosetta/identifier"
+	"github.com/optakt/flow-dps/rosetta/object"
 	"github.com/optakt/flow-dps/rosetta/transactor"
 	"github.com/optakt/flow-dps/testing/mocks"
 )

--- a/rosetta/transactor/transactor_test.go
+++ b/rosetta/transactor/transactor_test.go
@@ -1,0 +1,772 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package transactor_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	sdk "github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/optakt/flow-dps/models/dps"
+	"github.com/optakt/flow-dps/rosetta/object"
+
+	"github.com/optakt/flow-dps/rosetta/failure"
+	"github.com/optakt/flow-dps/rosetta/identifier"
+	"github.com/optakt/flow-dps/rosetta/transactor"
+	"github.com/optakt/flow-dps/testing/mocks"
+)
+
+func TestTransactor_DeriveIntent(t *testing.T) {
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		want := mocks.GenericOperations(2)
+		got, err := tr.DeriveIntent(want)
+
+		require.NoError(t, err)
+		assert.Equal(t, want[1].Amount.Value, fmt.Sprint(uint64(got.Amount)))
+		assert.Equal(t, want[1].AccountID.Address, got.To.String())
+		assert.Equal(t, want[0].AccountID.Address, got.From.String())
+		assert.Equal(t, want[0].AccountID.Address, got.Payer.String())
+		assert.Equal(t, want[0].AccountID.Address, got.Proposer.String())
+	})
+
+	t.Run("handles invalid currency", func(t *testing.T) {
+		t.Parallel()
+
+		validator := mocks.BaselineValidator(t)
+		validator.CurrencyFunc = func(identifier.Currency) (string, uint, error) {
+			return "", 0, mocks.GenericError
+		}
+
+		tr := transactor.BaselineTransactor(t, transactor.WithValidator(validator))
+
+		_, err := tr.DeriveIntent(mocks.GenericOperations(2))
+
+		assert.Error(t, err)
+	})
+
+	t.Run("handles invalid account", func(t *testing.T) {
+		t.Parallel()
+
+		validator := mocks.BaselineValidator(t)
+		validator.AccountFunc = func(account identifier.Account) (flow.Address, error) {
+			return flow.EmptyAddress, mocks.GenericError
+		}
+
+		tr := transactor.BaselineTransactor(t, transactor.WithValidator(validator))
+
+		_, err := tr.DeriveIntent(mocks.GenericOperations(2))
+
+		assert.Error(t, err)
+	})
+
+	t.Run("handles invalid number of operations", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		op := mocks.GenericOperations(3)
+
+		_, err := tr.DeriveIntent(op)
+
+		assert.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidOperations{})
+	})
+
+	t.Run("handles operations with unparsable amounts", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		op := mocks.GenericOperations(2)
+		op[0].Amount.Value = "42"
+		op[1].Amount.Value = "84"
+
+		_, err := tr.DeriveIntent(op)
+
+		assert.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidIntent{})
+	})
+
+	t.Run("handles operations with non-matching amounts", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		op := mocks.GenericOperations(2)
+		op[0].Amount.Value = "42"
+		op[1].Amount.Value = "84"
+
+		_, err := tr.DeriveIntent(op)
+
+		assert.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidIntent{})
+	})
+
+	t.Run("handles irrelevant currencies", func(t *testing.T) {
+		t.Parallel()
+
+		validator := mocks.BaselineValidator(t)
+		validator.CurrencyFunc = func(identifier.Currency) (string, uint, error) {
+			return "IRRELEVANT_CURRENCY", 0, nil
+		}
+
+		tr := transactor.BaselineTransactor(t, transactor.WithValidator(validator))
+
+		_, err := tr.DeriveIntent(mocks.GenericOperations(2))
+
+		assert.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidIntent{})
+	})
+
+	t.Run("handles non-transfer operations", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		op := mocks.GenericOperations(2)
+		op[0].Type = "irrelevant_type"
+
+		_, err := tr.DeriveIntent(op)
+
+		assert.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidIntent{})
+	})
+}
+
+func TestTransactor_CompileTransaction(t *testing.T) {
+	rosBlockID := mocks.GenericRosBlockID
+	sequence := uint64(42)
+
+	sender := mocks.GenericAddress(0)
+	receiver := mocks.GenericAddress(1)
+	amount, err := cadence.NewUFix64("100.00000000")
+	require.NoError(t, err)
+
+	intent := &transactor.Intent{
+		From:     sender,
+		To:       receiver,
+		Amount:   amount,
+		Payer:    sender,
+		Proposer: sender,
+	}
+
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		wantCompiled := `eyJTY3JpcHQiOiJkR1Z6ZEE9PSIsIkFyZ3VtZW50cyI6WyJleUowZVhCbElqb2lWVVpwZURZMElpd2lkbUZzZFdVaU9pSXhNREF1TURBd01EQXdNREFpZlFvPSIsImV5SjBlWEJsSWpvaVFXUmtjbVZ6Y3lJc0luWmhiSFZsSWpvaU1IaGpNamd5WlRJeVl6bGlNbVExTTJObUluMEsiXSwiUmVmZXJlbmNlQmxvY2tJRCI6WzcsNDAsMjgsMTUyLDIyOSwxNCwxMzMsNzgsOCwxOCwyNTIsMTI1LDExNywyMjAsMjIwLDY2LDE3NCwxNjIsMTUxLDcxLDEyNSw4OSw5MCw0MSwyMDIsMTE1LDY5LDIxOCwyMDIsMzYsMTQzLDU0XSwiR2FzTGltaXQiOjk5OTksIlByb3Bvc2FsS2V5Ijp7IkFkZHJlc3MiOiJlNmU0NjMyYWUwMTMwOWMwIiwiS2V5SW5kZXgiOjAsIlNlcXVlbmNlTnVtYmVyIjo0Mn0sIlBheWVyIjoiZTZlNDYzMmFlMDEzMDljMCIsIkF1dGhvcml6ZXJzIjpbImU2ZTQ2MzJhZTAxMzA5YzAiXSwiUGF5bG9hZFNpZ25hdHVyZXMiOm51bGwsIkVudmVsb3BlU2lnbmF0dXJlcyI6bnVsbH0=`
+
+		generator := mocks.BaselineGenerator(t)
+		generator.TransferTokensFunc = func(symbol string) ([]byte, error) {
+			assert.Equal(t, dps.FlowSymbol, symbol)
+
+			return mocks.GenericBytes, nil
+		}
+
+		tr := transactor.BaselineTransactor(t, transactor.WithGenerator(generator))
+
+		got, err := tr.CompileTransaction(rosBlockID, intent, sequence)
+
+		require.NoError(t, err)
+		assert.Equal(t, wantCompiled, got)
+	})
+
+	t.Run("handles generator failure on TransferTokens", func(t *testing.T) {
+		t.Parallel()
+
+		generator := mocks.BaselineGenerator(t)
+		generator.TransferTokensFunc = func(string) ([]byte, error) {
+			return nil, mocks.GenericError
+		}
+
+		tr := transactor.BaselineTransactor(t, transactor.WithGenerator(generator))
+
+		_, err := tr.CompileTransaction(rosBlockID, intent, sequence)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestTransactor_HashPayload(t *testing.T) {
+	header := mocks.GenericHeader
+	rosBlockID := mocks.GenericRosBlockID
+	signer := mocks.GenericAccountID(0)
+	signerAddr := mocks.GenericAddress(0)
+	tx := &sdk.Transaction{
+		ProposalKey: sdk.ProposalKey{SequenceNumber: 42},
+	}
+
+	key, err := generateKey()
+	require.NoError(t, err)
+
+	// We need to specify a weight of 1000 because otherwise multiple public keys would be required, as
+	// the total required weight for an account's signature to be considered valid has to be equal to 1000.
+	// For some reason this 1000 magic number is not exposed anywhere that I could find in Flow.
+	pubKey := key.PublicKey(1000)
+
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	payload := base64.StdEncoding.EncodeToString(data)
+
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		validator := mocks.BaselineValidator(t)
+		validator.BlockFunc = func(gotBlockID identifier.Block) (uint64, flow.Identifier, error) {
+			assert.Equal(t, rosBlockID, gotBlockID)
+
+			return header.Height, header.ID(), nil
+		}
+		validator.AccountFunc = func(rosAccountID identifier.Account) (flow.Address, error) {
+			assert.Equal(t, signer, rosAccountID)
+
+			return signerAddr, nil
+		}
+
+		invoker := mocks.BaselineInvoker(t)
+		invoker.KeyFunc = func(height uint64, address flow.Address, index int) (*flow.AccountPublicKey, error) {
+			assert.Equal(t, mocks.GenericHeight, height)
+			assert.Equal(t, signerAddr, address)
+			assert.Zero(t, index)
+
+			return &pubKey, nil
+		}
+
+		tr := transactor.BaselineTransactor(
+			t,
+			transactor.WithValidator(validator),
+			transactor.WithInvoker(invoker),
+		)
+
+		algorithm, hash, err := tr.HashPayload(rosBlockID, payload, signer)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ecdsa", algorithm)
+		assert.Equal(t, "3395952d355d9a5e9b5ba6f46f155cca9ec7615deef5ce1146926cb4abbf5cbb", hash)
+	})
+
+	t.Run("handles non-base64-encoded transaction payload", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		data, err := json.Marshal(tx)
+		require.NoError(t, err)
+
+		_, _, err = tr.HashPayload(rosBlockID, string(data), signer)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidPayload{})
+	})
+
+	t.Run("handles non-json-encoded transaction payload", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		invalidPayload := base64.StdEncoding.EncodeToString(mocks.GenericBytes)
+
+		_, _, err = tr.HashPayload(rosBlockID, invalidPayload, signer)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidPayload{})
+	})
+
+	t.Run("handles invalid block", func(t *testing.T) {
+		t.Parallel()
+
+		validator := mocks.BaselineValidator(t)
+		validator.BlockFunc = func(identifier.Block) (uint64, flow.Identifier, error) {
+			return 0, flow.ZeroID, mocks.GenericError
+		}
+
+		tr := transactor.BaselineTransactor(
+			t,
+			transactor.WithValidator(validator),
+		)
+
+		_, _, err := tr.HashPayload(rosBlockID, payload, signer)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("handles invalid account", func(t *testing.T) {
+		t.Parallel()
+
+		validator := mocks.BaselineValidator(t)
+		validator.AccountFunc = func(identifier.Account) (flow.Address, error) {
+			return flow.EmptyAddress, mocks.GenericError
+		}
+
+		tr := transactor.BaselineTransactor(
+			t,
+			transactor.WithValidator(validator),
+		)
+
+		_, _, err := tr.HashPayload(rosBlockID, payload, signer)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("handles invoker failure on Key", func(t *testing.T) {
+		t.Parallel()
+
+		invoker := mocks.BaselineInvoker(t)
+		invoker.KeyFunc = func(uint64, flow.Address, int) (*flow.AccountPublicKey, error) {
+			return nil, mocks.GenericError
+		}
+
+		tr := transactor.BaselineTransactor(
+			t,
+			transactor.WithInvoker(invoker),
+		)
+
+		_, _, err := tr.HashPayload(rosBlockID, payload, signer)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidKey{})
+	})
+}
+
+func TestTransactor_Parse(t *testing.T) {
+	tx := &sdk.Transaction{
+		ProposalKey: sdk.ProposalKey{SequenceNumber: 42},
+	}
+
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := json.Marshal(tx)
+		require.NoError(t, err)
+
+		encodedData := base64.StdEncoding.EncodeToString(data)
+
+		tr := transactor.BaselineTransactor(t)
+
+		got, err := tr.Parse(encodedData)
+
+		require.NoError(t, err)
+		assert.Equal(t, tx.ProposalKey.SequenceNumber, got.Sequence())
+	})
+
+	t.Run("handles missing base64 encoding", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := json.Marshal(tx)
+		require.NoError(t, err)
+
+		tr := transactor.BaselineTransactor(t)
+
+		_, err = tr.Parse(string(data))
+
+		assert.Error(t, err)
+	})
+
+	t.Run("handles non-JSON-encoded payloads", func(t *testing.T) {
+		t.Parallel()
+
+		payload := mocks.GenericBytes
+
+		tr := transactor.BaselineTransactor(t)
+
+		_, err := tr.Parse(string(payload))
+
+		assert.Error(t, err)
+	})
+}
+
+func TestTransactor_AttachSignatures(t *testing.T) {
+	senderID := mocks.GenericAccountID(0)
+	sender := sdk.HexToAddress(mocks.GenericAddress(0).Hex())
+	receiverID := mocks.GenericAccountID(1)
+	receiver := sdk.HexToAddress(mocks.GenericAddress(1).Hex())
+	tx := &sdk.Transaction{
+		Authorizers: []sdk.Address{
+			sender,
+		},
+		Payer: sender,
+	}
+
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	payload := base64.StdEncoding.EncodeToString(data)
+
+	key, err := generateKey()
+	require.NoError(t, err)
+
+	// We need to specify a weight of 1000 because otherwise multiple public keys would be required, as
+	// the total required weight for an account's signature to be considered valid has to be equal to 1000.
+	// For some reason this 1000 magic number is not exposed anywhere that I could find in Flow.
+	pubKey := key.PublicKey(1000)
+	hexBytes := strings.TrimPrefix(pubKey.PublicKey.String(), "0x")
+	senderSignature := object.Signature{
+		SigningPayload: object.SigningPayload{
+			AccountID:     senderID,
+			HexBytes:      hexBytes,
+			SignatureType: "ecdsa",
+		},
+		SignatureType: "ecdsa",
+		HexBytes:      hexBytes,
+		PublicKey: object.PublicKey{
+			HexBytes: hexBytes,
+		},
+	}
+	receiverSignature := object.Signature{
+		SigningPayload: object.SigningPayload{
+			AccountID:     receiverID,
+			HexBytes:      hexBytes,
+			SignatureType: "ecdsa",
+		},
+		SignatureType: "ecdsa",
+		HexBytes:      hexBytes,
+		PublicKey: object.PublicKey{
+			HexBytes: hexBytes,
+		},
+	}
+	signatures := []object.Signature{senderSignature}
+
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		got, err := tr.AttachSignatures(payload, signatures)
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, got)
+	})
+
+	t.Run("handles non-base64-encoded transaction payload", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		invalidPayload, err := json.Marshal(tx)
+		require.NoError(t, err)
+
+		_, err = tr.AttachSignatures(string(invalidPayload), signatures)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidPayload{})
+	})
+
+	t.Run("handles non-json-encoded transaction payload", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		invalidPayload := base64.StdEncoding.EncodeToString(mocks.GenericBytes)
+
+		_, err = tr.AttachSignatures(invalidPayload, signatures)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidPayload{})
+	})
+
+	t.Run("handles invalid number of authorizers (>)", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		tx := &sdk.Transaction{
+			Authorizers: []sdk.Address{
+				sender,
+				sender,
+			},
+			Payer: sender,
+		}
+
+		data, err := json.Marshal(tx)
+		require.NoError(t, err)
+
+		payload := base64.StdEncoding.EncodeToString(data)
+
+		_, err = tr.AttachSignatures(payload, signatures)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidAuthorizers{})
+	})
+
+	t.Run("handles invalid number of authorizers (0)", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		tx := &sdk.Transaction{
+			Authorizers: []sdk.Address{},
+			Payer:       sender,
+		}
+
+		data, err := json.Marshal(tx)
+		require.NoError(t, err)
+
+		payload := base64.StdEncoding.EncodeToString(data)
+
+		_, err = tr.AttachSignatures(payload, signatures)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidAuthorizers{})
+	})
+
+	t.Run("handles mismatch between length of signatures and authorizers", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		signatures := []object.Signature{senderSignature, senderSignature, senderSignature} // 3 signatures but only 1 authorizer.
+
+		_, err = tr.AttachSignatures(payload, signatures)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidSignatures{})
+	})
+
+	t.Run("handles mismatch between payer and sender", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		tx := &sdk.Transaction{
+			Authorizers: []sdk.Address{sender},
+			Payer:       receiver,
+		}
+
+		data, err := json.Marshal(tx)
+		require.NoError(t, err)
+
+		payload := base64.StdEncoding.EncodeToString(data)
+
+		_, err = tr.AttachSignatures(payload, signatures)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidPayer{})
+	})
+
+	t.Run("handles unexpected envelope signatures", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		tx := &sdk.Transaction{
+			Authorizers:        []sdk.Address{sender},
+			Payer:              sender,
+			EnvelopeSignatures: []sdk.TransactionSignature{{}}, // 1 empty senderSignature just to trigger the failure.
+		}
+
+		data, err := json.Marshal(tx)
+		require.NoError(t, err)
+
+		payload := base64.StdEncoding.EncodeToString(data)
+
+		_, err = tr.AttachSignatures(payload, signatures)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidSignature{})
+	})
+
+	t.Run("handles mismatch between signer and sender", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		signatures := []object.Signature{receiverSignature} // Signed by receiver instead of sender.
+
+		_, err = tr.AttachSignatures(payload, signatures)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidSignature{})
+	})
+
+	t.Run("handles invalid signature algorithm", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		signatures := []object.Signature{
+			{
+				SigningPayload: object.SigningPayload{
+					AccountID:     senderID,
+					HexBytes:      hexBytes,
+					SignatureType: "invalid_type",
+				},
+				SignatureType: "invalid_type",
+				HexBytes:      hexBytes,
+				PublicKey: object.PublicKey{
+					HexBytes: hexBytes,
+				},
+			},
+		}
+
+		_, err = tr.AttachSignatures(payload, signatures)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidSignature{})
+	})
+
+	t.Run("handles invalid signature bytes", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		signatures := []object.Signature{
+			{
+				SigningPayload: object.SigningPayload{
+					AccountID:     senderID,
+					HexBytes:      string(mocks.GenericBytes),
+					SignatureType: "ecdsa",
+				},
+				SignatureType: "ecdsa",
+				HexBytes:      string(mocks.GenericBytes),
+				PublicKey: object.PublicKey{
+					HexBytes: string(mocks.GenericBytes),
+				},
+			},
+		}
+
+		_, err = tr.AttachSignatures(payload, signatures)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidSignature{})
+	})
+}
+
+func TestTransactor_TransactionIdentifier(t *testing.T) {
+	tx := &sdk.Transaction{}
+
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	payload := base64.StdEncoding.EncodeToString(data)
+
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		got, err := tr.TransactionIdentifier(payload)
+
+		require.NoError(t, err)
+		assert.Equal(t, tx.ID().Hex(), got.Hash)
+	})
+
+	t.Run("handles non-base64-encoded transaction payload", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		invalidPayload, err := json.Marshal(tx)
+		require.NoError(t, err)
+
+		_, err = tr.TransactionIdentifier(string(invalidPayload))
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidPayload{})
+	})
+
+	t.Run("handles non-json-encoded transaction payload", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		invalidPayload := base64.StdEncoding.EncodeToString(mocks.GenericBytes)
+
+		_, err = tr.TransactionIdentifier(invalidPayload)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidPayload{})
+	})
+}
+
+func TestTransactor_SubmitTransaction(t *testing.T) {
+	tx := &sdk.Transaction{}
+
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	payload := base64.StdEncoding.EncodeToString(data)
+
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		submitter := mocks.BaselineSubmitter(t)
+		submitter.TransactionFunc = func(gotTx *sdk.Transaction) error {
+			assert.Equal(t, tx, gotTx)
+
+			return nil
+		}
+
+		tr := transactor.BaselineTransactor(t, transactor.WithSubmitter(submitter))
+
+		got, err := tr.SubmitTransaction(payload)
+
+		require.NoError(t, err)
+		assert.Equal(t, tx.ID().Hex(), got.Hash)
+	})
+
+	t.Run("handles non-base64-encoded transaction payload", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		invalidPayload, err := json.Marshal(tx)
+		require.NoError(t, err)
+
+		_, err = tr.SubmitTransaction(string(invalidPayload))
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidPayload{})
+	})
+
+	t.Run("handles non-json-encoded transaction payload", func(t *testing.T) {
+		t.Parallel()
+
+		tr := transactor.BaselineTransactor(t)
+
+		invalidPayload := base64.StdEncoding.EncodeToString(mocks.GenericBytes)
+
+		_, err = tr.SubmitTransaction(invalidPayload)
+
+		require.Error(t, err)
+		assert.ErrorAs(t, err, &failure.InvalidPayload{})
+	})
+
+	t.Run("handles submitter failure", func(t *testing.T) {
+		t.Parallel()
+
+		submitter := mocks.BaselineSubmitter(t)
+		submitter.TransactionFunc = func(*sdk.Transaction) error {
+			return mocks.GenericError
+		}
+
+		tr := transactor.BaselineTransactor(t, transactor.WithSubmitter(submitter))
+
+		_, err := tr.SubmitTransaction(payload)
+
+		assert.Error(t, err)
+	})
+}

--- a/service/chain/disk_test.go
+++ b/service/chain/disk_test.go
@@ -41,7 +41,6 @@ func TestDisk_Root(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		root, err := c.Root()
-
 		require.NoError(t, err)
 		assert.Equal(t, mocks.GenericHeight, root)
 	})
@@ -55,7 +54,6 @@ func TestDisk_Root(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		_, err := c.Root()
-
 		assert.Error(t, err)
 	})
 }
@@ -127,7 +125,6 @@ func TestDisk_Commit(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		commit, err := c.Commit(mocks.GenericHeight)
-
 		require.NoError(t, err)
 		assert.Equal(t, mocks.GenericCommit(0), commit)
 
@@ -180,14 +177,12 @@ func TestDisk_Events(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		events, err := c.Events(mocks.GenericHeight)
-
 		require.NoError(t, err)
 		assert.Len(t, events, 2)
 		assert.Contains(t, events, mocks.GenericEvent(0))
 		assert.Contains(t, events, mocks.GenericEvent(1))
 
 		_, err = c.Events(math.MaxUint64)
-
 		assert.Error(t, err)
 	})
 
@@ -200,7 +195,6 @@ func TestDisk_Events(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		_, err := c.Events(mocks.GenericHeight)
-
 		assert.Error(t, err)
 	})
 }
@@ -220,7 +214,6 @@ func TestDisk_Collections(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		tt, err := c.Collections(mocks.GenericHeight)
-
 		require.NoError(t, err)
 		assert.Len(t, tt, 2)
 
@@ -273,7 +266,6 @@ func TestDisk_Guarantees(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		tt, err := c.Guarantees(mocks.GenericHeight)
-
 		require.NoError(t, err)
 		assert.Len(t, tt, 2)
 
@@ -330,7 +322,6 @@ func TestDisk_Transactions(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		tt, err := c.Transactions(mocks.GenericHeight)
-
 		require.NoError(t, err)
 		assert.Len(t, tt, 4)
 
@@ -384,12 +375,10 @@ func TestDisk_TransactionResults(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		tr, err := c.Results(mocks.GenericHeight)
-
 		require.NoError(t, err)
 		assert.Len(t, tr, 4)
 
 		_, err = c.Results(math.MaxUint64)
-
 		assert.Error(t, err)
 	})
 
@@ -402,7 +391,6 @@ func TestDisk_TransactionResults(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		_, err := c.Results(mocks.GenericHeight)
-
 		assert.Error(t, err)
 	})
 }
@@ -424,7 +412,6 @@ func TestDisk_Seals(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		seals, err := c.Seals(mocks.GenericHeight)
-
 		require.NoError(t, err)
 		assert.Len(t, seals, 4)
 

--- a/service/chain/disk_test.go
+++ b/service/chain/disk_test.go
@@ -41,6 +41,7 @@ func TestDisk_Root(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		root, err := c.Root()
+
 		require.NoError(t, err)
 		assert.Equal(t, mocks.GenericHeight, root)
 	})
@@ -54,6 +55,7 @@ func TestDisk_Root(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		_, err := c.Root()
+
 		assert.Error(t, err)
 	})
 }
@@ -125,6 +127,7 @@ func TestDisk_Commit(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		commit, err := c.Commit(mocks.GenericHeight)
+
 		require.NoError(t, err)
 		assert.Equal(t, mocks.GenericCommit(0), commit)
 
@@ -177,12 +180,14 @@ func TestDisk_Events(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		events, err := c.Events(mocks.GenericHeight)
+
 		require.NoError(t, err)
 		assert.Len(t, events, 2)
 		assert.Contains(t, events, mocks.GenericEvent(0))
 		assert.Contains(t, events, mocks.GenericEvent(1))
 
 		_, err = c.Events(math.MaxUint64)
+
 		assert.Error(t, err)
 	})
 
@@ -195,6 +200,7 @@ func TestDisk_Events(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		_, err := c.Events(mocks.GenericHeight)
+
 		assert.Error(t, err)
 	})
 }
@@ -214,6 +220,7 @@ func TestDisk_Collections(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		tt, err := c.Collections(mocks.GenericHeight)
+
 		require.NoError(t, err)
 		assert.Len(t, tt, 2)
 
@@ -266,6 +273,7 @@ func TestDisk_Guarantees(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		tt, err := c.Guarantees(mocks.GenericHeight)
+
 		require.NoError(t, err)
 		assert.Len(t, tt, 2)
 
@@ -322,6 +330,7 @@ func TestDisk_Transactions(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		tt, err := c.Transactions(mocks.GenericHeight)
+
 		require.NoError(t, err)
 		assert.Len(t, tt, 4)
 
@@ -375,10 +384,12 @@ func TestDisk_TransactionResults(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		tr, err := c.Results(mocks.GenericHeight)
+
 		require.NoError(t, err)
 		assert.Len(t, tr, 4)
 
 		_, err = c.Results(math.MaxUint64)
+
 		assert.Error(t, err)
 	})
 
@@ -391,6 +402,7 @@ func TestDisk_TransactionResults(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		_, err := c.Results(mocks.GenericHeight)
+
 		assert.Error(t, err)
 	})
 }
@@ -412,6 +424,7 @@ func TestDisk_Seals(t *testing.T) {
 		c := chain.FromDisk(db)
 
 		seals, err := c.Seals(mocks.GenericHeight)
+
 		require.NoError(t, err)
 		assert.Len(t, seals, 4)
 

--- a/testing/mocks/generator.go
+++ b/testing/mocks/generator.go
@@ -20,20 +20,24 @@ type Generator struct {
 	GetBalanceFunc      func(symbol string) ([]byte, error)
 	TokensDepositedFunc func(symbol string) (string, error)
 	TokensWithdrawnFunc func(symbol string) (string, error)
+	TransferTokensFunc  func(symbol string) ([]byte, error)
 }
 
 func BaselineGenerator(t *testing.T) *Generator {
 	t.Helper()
 
 	g := Generator{
-		GetBalanceFunc: func(symbol string) ([]byte, error) {
+		GetBalanceFunc: func(string) ([]byte, error) {
 			return []byte(GenericAmount(0).String()), nil
 		},
-		TokensDepositedFunc: func(symbol string) (string, error) {
+		TokensDepositedFunc: func(string) (string, error) {
 			return string(GenericEventType(0)), nil
 		},
-		TokensWithdrawnFunc: func(symbol string) (string, error) {
+		TokensWithdrawnFunc: func(string) (string, error) {
 			return string(GenericEventType(1)), nil
+		},
+		TransferTokensFunc: func(string) ([]byte, error) {
+			return GenericBytes, nil
 		},
 	}
 
@@ -50,4 +54,8 @@ func (g *Generator) TokensDeposited(symbol string) (string, error) {
 
 func (g *Generator) TokensWithdrawn(symbol string) (string, error) {
 	return g.TokensWithdrawnFunc(symbol)
+}
+
+func (g *Generator) TransferTokens(symbol string) ([]byte, error) {
+	return g.TransferTokensFunc(symbol)
 }

--- a/testing/mocks/generic.go
+++ b/testing/mocks/generic.go
@@ -27,6 +27,8 @@ import (
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime/tests/utils"
+	"github.com/onflow/flow-go/crypto"
+	chash "github.com/onflow/flow-go/crypto/hash"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/hash"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/node"
@@ -128,6 +130,14 @@ var (
 	GenericAccount = flow.Account{
 		Address: GenericAddress(0),
 		Balance: 84,
+		Keys: []flow.AccountPublicKey{
+			{
+				Index:     0,
+				SeqNumber: 42,
+				HashAlgo:  chash.SHA2_256,
+				PublicKey: crypto.NeutralBLSPublicKey(), // FIXME: Is this fine as a mock key?
+			},
+		},
 	}
 
 	GenericRosBlockID = identifier.Block{
@@ -384,7 +394,7 @@ func GenericOperations(number int) []object.Operation {
 		account := GenericAccountID(i % 2)
 
 		// Simulate that every second operation is the withdrawal.
-		value := GenericAmount(i).String()
+		value := GenericAmount(i / 2).String()
 		if i%2 == 1 {
 			value = "-" + value
 		}

--- a/testing/mocks/generic.go
+++ b/testing/mocks/generic.go
@@ -135,7 +135,7 @@ var (
 				Index:     0,
 				SeqNumber: 42,
 				HashAlgo:  chash.SHA2_256,
-				PublicKey: crypto.NeutralBLSPublicKey(), // FIXME: Is this fine as a mock key?
+				PublicKey: crypto.NeutralBLSPublicKey(),
 			},
 		},
 	}

--- a/testing/mocks/submitter.go
+++ b/testing/mocks/submitter.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package mocks
+
+import (
+	"testing"
+
+	sdk "github.com/onflow/flow-go-sdk"
+)
+
+type Submitter struct {
+	TransactionFunc func(tx *sdk.Transaction) error
+}
+
+func (s *Submitter) Transaction(tx *sdk.Transaction) error {
+	return s.TransactionFunc(tx)
+}
+
+func BaselineSubmitter(t *testing.T) *Submitter {
+	t.Helper()
+
+	s := Submitter{
+		TransactionFunc: func(tx *sdk.Transaction) error {
+			return nil
+		},
+	}
+
+	return &s
+}


### PR DESCRIPTION
## Goal of this PR

Part of #333 

* Adds tests to the new Transactor component, introduced by the Rosetta Construction API (#387) and the new method on the rosetta retriever, `Sequence`.
* Refactors the `ParseTransaction` method from the `Transactor` into its own dedicated type for readability and testability.

## Additional Notes

```go
// FIXME: The naming of those funcs conflict with the transactor's, since they have the same dependencies :(
//        How can we name this in a consistent way that makes sense?
func ParseTransaction(tx *sdk.Transaction) func(*TransactionParser) {
	return func(parser *TransactionParser) {
		parser.tx = tx
	}
}

func ParseValidator(validate Validator) func(*TransactionParser) {
	return func(parser *TransactionParser) {
		parser.validate = validate
	}
}

func ParseGenerator(generate Generator) func(*TransactionParser) {
	return func(parser *TransactionParser) {
		parser.generate = generate
	}
}

func ParseInvoker(invoke Invoker) func(*TransactionParser) {
	return func(parser *TransactionParser) {
		parser.invoke = invoke
	}
}
```

Any suggestions? Since we already have `WithX` for injecting those dependencies to the Transactor in the same package.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date