### PR TITLE
Remove darwin builds from release config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,40 +4,56 @@
 builds:
   - id: dps-client
     binary: dps-client
+    main: ./cmd/flow-dps-client
+    goos:
+      - linux
     goarch:
       - amd64
-    main: ./cmd/flow-dps-client
+    flags:
+      - -tags=relic
 
   - id: dps-indexer
     binary: dps-indexer
+    main: ./cmd/flow-dps-indexer
+    goos:
+      - linux
     goarch:
       - amd64
-    main: ./cmd/flow-dps-indexer
+    flags:
+      - -tags=relic
 
   - id: dps-server
     binary: dps-server
+    main: ./cmd/flow-dps-server
+    goos:
+      - linux
     goarch:
       - amd64
-    main: ./cmd/flow-dps-server
+    flags:
+      - -tags=relic
 
   - id: dps-live
     binary: dps-live
+    main: ./cmd/flow-dps-live
+    goos:
+      - linux
     goarch:
       - amd64
-    main: ./cmd/flow-dps-live
     flags:
       - -tags=relic
 
   - id: rosetta-server
     binary: rosetta-server
+    main: ./cmd/flow-rosetta-server
+    goos:
+      - linux
     goarch:
       - amd64
-    main: ./cmd/flow-rosetta-server
+    flags:
+      - -tags=relic
+
 archives:
   - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
       386: i386
       amd64: x86_64
 checksum:


### PR DESCRIPTION
## Goal of this PR

Fixes goreleaser script on master.

```sh
goreleaser build --skip-validate --rm-dist
   • building...
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • building...               commit=125369dfc8e7f33a6b5fea1c86d49af3f7bfd5c8 latest tag=v1.2.0
      • pipe skipped              error=validation is disabled
   • parsing tag
   • running before hooks
   • setting defaults
      • snapshotting
      • github/gitlab/gitea releases
      • project name
      • loading go mod information
      • building binaries
      • creating source archive
      • archives
      • linux packages
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • signing docker images
      • docker images
      • docker manifests
      • artifactory
      • blobs
      • homebrew tap formula
      • scoop manifests
      • twitter
      • milestones
   • snapshotting
   • checking ./dist
      • --rm-dist is set, cleaning it up
   • loading go mod information
   • writing effective config file
      • writing                   config=dist/config.yaml
   • generating changelog
      • writing                   changelog=dist/CHANGELOG.md
   • building binaries
      • building                  binary=/mnt/g/Work/dps/dist/dps-client_linux_amd64/dps-client
      • building                  binary=/mnt/g/Work/dps/dist/dps-indexer_linux_amd64/dps-indexer
      • building                  binary=/mnt/g/Work/dps/dist/dps-server_linux_amd64/dps-server
      • building                  binary=/mnt/g/Work/dps/dist/dps-live_linux_amd64/dps-live
      • building                  binary=/mnt/g/Work/dps/dist/rosetta-server_linux_amd64/rosetta-server
   • build succeeded after 13.76s
```