### PR TITLE
Make GitHub actions manually triggerable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 # Continuous integration will run whenever a pull request for the master branch
 # is created or updated.
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: AutoRelease
 
 # AutoRelease will run whenever a tag is pushed.
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*'


### PR DESCRIPTION
## Goal of this PR

This PR should make our GitHub actions able to be triggered manually.

We might also need to give some extra permissions in the repo settings, but not 100% sure this is still up to date. Basically workflow dispatch uses a webhook, so webhook events have to be allowed somehow. See [this documentation](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#manual-events).

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date