### PR TITLE
Live: improve downloader performance

### DIFF
--- a/service/cloud/config.go
+++ b/service/cloud/config.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package cloud
+
+var DefaultConfig = Config{
+	BufferSize: 8,
+}
+
+type Config struct {
+	BufferSize uint
+}
+
+type Option func(*Config)
+
+func WithBufferSize(size uint) Option {
+	return func(cfg *Config) {
+		cfg.BufferSize = size
+	}
+}

--- a/service/cloud/config.go
+++ b/service/cloud/config.go
@@ -15,7 +15,7 @@
 package cloud
 
 var DefaultConfig = Config{
-	BufferSize: 8,
+	BufferSize: 32,
 }
 
 type Config struct {

--- a/service/cloud/gcp_streamer.go
+++ b/service/cloud/gcp_streamer.go
@@ -36,19 +36,24 @@ type GCPStreamer struct {
 	bucket *storage.BucketHandle
 	queue  *deque.Deque // queue of block identifiers for next downloads
 	buffer *deque.Deque // queue of downloaded execution data records
+	limit  uint         // buffer size limit for downloaded records
 	busy   uint32       // used as a guard to avoid concurrent polling
-	limit  uint
 }
 
-func NewGCPStreamer(log zerolog.Logger, bucket *storage.BucketHandle) *GCPStreamer {
+func NewGCPStreamer(log zerolog.Logger, bucket *storage.BucketHandle, options ...Option) *GCPStreamer {
+
+	cfg := DefaultConfig
+	for _, option := range options {
+		option(&cfg)
+	}
 
 	g := GCPStreamer{
 		log:    log.With().Str("component", "gcp_streamer").Logger(),
 		bucket: bucket,
 		queue:  deque.New(),
 		buffer: deque.New(),
+		limit:  cfg.BufferSize,
 		busy:   0,
-		limit:  100,
 	}
 
 	return &g

--- a/service/cloud/gcp_streamer.go
+++ b/service/cloud/gcp_streamer.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync"
 	"sync/atomic"
 
 	"cloud.google.com/go/storage"
@@ -38,7 +37,6 @@ type GCPStreamer struct {
 	queue  *deque.Deque // queue of block identifiers for next downloads
 	buffer *deque.Deque // queue of downloaded execution data records
 	busy   uint32       // used as a guard to avoid concurrent polling
-	wg     *sync.WaitGroup
 	limit  uint
 }
 
@@ -50,8 +48,7 @@ func NewGCPStreamer(log zerolog.Logger, bucket *storage.BucketHandle) *GCPStream
 		queue:  deque.New(),
 		buffer: deque.New(),
 		busy:   0,
-		wg:     &sync.WaitGroup{},
-		limit:  8,
+		limit:  100,
 	}
 
 	return &g
@@ -68,41 +65,29 @@ func (g *GCPStreamer) OnBlockFinalized(blockID flow.Identifier) {
 
 func (g *GCPStreamer) Next() (*uploader.BlockData, error) {
 
-	// We want to be able to wait for a poll to successfully complete before
-	// returning, so we add to the waiting group and start the polling in the
-	// background.
-	g.wg.Add(1)
+	// If we are not polling already, we want to start polling in the
+	// background. This will try to fill the buffer up until its limit is
+	// reached. It basically means that the cloud streamer will always be
+	// downloading if something is available and the execution tracker is asking
+	// for the next record.
 	go g.poll()
 
-	// However, in case we already have items in the buffer, we prefer to return
-	// immediately and complete the polling in the background, so the buffer is
-	// filled again for the next request. We thus only wait on the wait group if
-	// the buffer is empty.
-	if g.buffer.Len() == 0 {
-		g.log.Debug().Msg("buffer empty, waiting for poll")
-		g.wg.Wait()
-	}
-
-	// At this point, we waited for polling to finish. If the buffer is still
-	// empty, it means there is no new data available on the cloud, and we can
-	// return the corresponding error.
+	// If we have nothing in the buffer, we can return the unavailable error,
+	// which will cause the mapper logic to go into a wait state and retry a bit
+	// later.
 	if g.buffer.Len() == 0 {
 		g.log.Debug().Msg("buffer still empty, no data available")
 		return nil, dps.ErrUnavailable
 	}
 
-	// When we get here, we either had a full buffer before finishing polling,
-	// or the buffer was filled up again by the polling. We can thus pop an item
-	// from the buffer and return it.
+	// If we have a record in the buffer, we will just return it. The buffer is
+	// concurrency safe, so there is no problem with popping from the back while
+	// the poll is pushing new items in the front.
 	record := g.buffer.PopBack()
 	return record.(*uploader.BlockData), nil
 }
 
 func (g *GCPStreamer) poll() {
-
-	// We defer the call to done, so that the consumer is notified of the
-	// finished poll in case it is waiting.
-	defer g.wg.Done()
 
 	// We only call `Next()` sequentially, so there is no need to guard it from
 	// concurrent access. However, when the buffer is not empty, we might still


### PR DESCRIPTION
## Goal of this PR

This PR increases the size of the downloader's buffer, so it will keep polling more blocks in the background than it otherwise would have. At the same time, this means that a single `Next()` call with an empty buffer would wait a _long_ time to return (until the entire poll is finished). It was already slow with 8 instead of 100. So with this change, it will never wait for the buffer to be full, but instead return to the business logic which will have a much smaller wait. Combined, these changes should significantly reduce initial sync time.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date