### PR TITLE
Fix execution record download retry

### DIFF
--- a/service/cloud/gcp_streamer.go
+++ b/service/cloud/gcp_streamer.go
@@ -147,8 +147,8 @@ func (g *GCPStreamer) download() error {
 		// Get the name of the file based on the block ID. The file name is
 		// made up of the block ID in hex and a `.cbor` extension, see:
 		// Maks: "thats correct. In fact the full name is `<blockID>.cbor`"
-		// If the file is not found, we put the block ID back into the queue
-		// and return `nil` to stop pulling.
+		// If we encounter an error, such as that the file is not found, we put
+		// the block ID back into the queue and return `nil` to stop pulling.
 		blockID := g.queue.PopBack().(flow.Identifier)
 		name := blockID.String() + ".cbor"
 		record, err := g.pullRecord(name)

--- a/service/tracker/consensus.go
+++ b/service/tracker/consensus.go
@@ -71,9 +71,9 @@ func (c *Consensus) OnBlockFinalized(blockID flow.Identifier) {
 		return
 	}
 
-	c.log.Debug().Hex("block", blockID[:]).Uint64("height", header.Height).Msg("block finalization processed")
-
 	c.last = header.Height
+
+	c.log.Debug().Hex("block", blockID[:]).Uint64("height", header.Height).Msg("block finalization processed")
 }
 
 // Root returns the root height from the underlying protocol state.

--- a/service/tracker/execution.go
+++ b/service/tracker/execution.go
@@ -120,7 +120,7 @@ func (e *Execution) Update() (*ledger.TrieUpdate, error) {
 	// it to the chain interface as needed.
 	err := e.processNext()
 	if err != nil {
-		return nil, fmt.Errorf("could not process next record: %w", err)
+		return nil, fmt.Errorf("could not process next execution record: %w", err)
 	}
 
 	// This is a recursive function call. It allows us to skip past blocks which
@@ -147,7 +147,7 @@ func (e *Execution) Record(blockID flow.Identifier) (*uploader.BlockData, error)
 	// the next one from the cloud reader.
 	err := e.processNext()
 	if err != nil {
-		return nil, fmt.Errorf("could not process next record: %w", err)
+		return nil, fmt.Errorf("could not process next execution record: %w", err)
 	}
 
 	// This is a recursive function call. It allows us to keep reading block
@@ -161,7 +161,7 @@ func (e *Execution) processNext() error {
 	// Get the next block execution record available from the cloud streamer.
 	record, err := e.stream.Next()
 	if err != nil {
-		return fmt.Errorf("could not read record: %w", err)
+		return fmt.Errorf("could not read next execution record: %w", err)
 	}
 
 	// Check if we already processed a block with this ID recently. This should
@@ -169,7 +169,7 @@ func (e *Execution) processNext() error {
 	blockID := record.Block.Header.ID()
 	_, ok := e.records[blockID]
 	if ok {
-		return fmt.Errorf("duplicate block record (block: %x)", blockID)
+		return fmt.Errorf("duplicate execution record (block: %x)", blockID)
 	}
 
 	// Dump the block execution record into our cache and push all trie updates
@@ -190,7 +190,7 @@ func (e *Execution) processNext() error {
 	e.log.Debug().
 		Hex("block", blockID[:]).
 		Int("updates", len(record.TrieUpdates)).
-		Msg("processed next block record")
+		Msg("next execution record processed")
 
 	return nil
 }


### PR DESCRIPTION
## Goal of this PR

There is a bug that the cloud streamer will only try to download the execution record for a finalized block once. If it fails, it will not put the block ID back into the queue. If that block has any valid trie updates, we will no longer be able to properly recreate the execution history.

The bug was only uncovered when a massive block was not available for download for a long time, while it had been finalized much earlier. It appears that in almost all cases, execution is faster than finalization, at least on the canary network. This is why the bug only manifested now.