### PR TITLE
Move the network validation code to the validator

### DIFF
--- a/api/rosetta/balance.go
+++ b/api/rosetta/balance.go
@@ -54,11 +54,6 @@ func (d *Data) Balance(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = d.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	rosBlockID, balances, err := d.retrieve.Balances(req.BlockID, req.AccountID, req.Currencies)
 	if err != nil {
 		return apiError(balancesRetrieval, err)

--- a/api/rosetta/block.go
+++ b/api/rosetta/block.go
@@ -52,11 +52,6 @@ func (d *Data) Block(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = d.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	block, extraTxIDs, err := d.retrieve.Block(req.BlockID)
 	if err != nil {
 		return apiError(blockRetrieval, err)

--- a/api/rosetta/combine.go
+++ b/api/rosetta/combine.go
@@ -54,11 +54,6 @@ func (c *Construction) Combine(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = c.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	signed, err := c.transact.AttachSignatures(req.UnsignedTransaction, req.Signatures)
 	if err != nil {
 		return apiError(txSigning, err)

--- a/api/rosetta/configuration.go
+++ b/api/rosetta/configuration.go
@@ -29,5 +29,4 @@ type Configuration interface {
 	Operations() []string
 	Statuses() []meta.StatusDefinition
 	Errors() []meta.ErrorDefinition
-	Check(rosNetID identifier.Network) error
 }

--- a/api/rosetta/data_integration_test.go
+++ b/api/rosetta/data_integration_test.go
@@ -100,7 +100,7 @@ func setupAPI(t *testing.T, db *badger.DB) *rosetta.Data {
 
 	params := dps.FlowParams[dps.FlowTestnet]
 	config := configuration.New(params.ChainID)
-	validate := validator.New(params, index)
+	validate := validator.New(params, index, config)
 	generate := scripts.NewGenerator(params)
 	invoke, err := invoker.New(index)
 	require.NoError(t, err)

--- a/api/rosetta/errors.go
+++ b/api/rosetta/errors.go
@@ -139,8 +139,8 @@ func invalidNetwork(fail failure.InvalidNetwork) Error {
 	return convertError(
 		configuration.ErrorInvalidNetwork,
 		fail.Description,
-		withDetail("network", fail.HaveNetwork),
-		withDetail("available_networks", fail.AvailableNetworks),
+		withDetail("have_network", fail.HaveNetwork),
+		withDetail("want_network", fail.WantNetwork),
 	)
 }
 
@@ -148,8 +148,8 @@ func invalidBlockchain(fail failure.InvalidBlockchain) Error {
 	return convertError(
 		configuration.ErrorInvalidNetwork,
 		fail.Description,
-		withDetail("blockchain", fail.HaveBlockchain),
-		withDetail("available_blockchains", fail.AvailableBlockchains),
+		withDetail("have_blockchain", fail.HaveBlockchain),
+		withDetail("want_blockchain", fail.WantBlockchain),
 	)
 }
 

--- a/api/rosetta/errors.go
+++ b/api/rosetta/errors.go
@@ -44,7 +44,7 @@ const (
 	TxBodyEmpty     = "transaction text is empty"
 	SignaturesEmpty = "signature list is empty"
 
-	networkCheck            = "unable to check network"
+	NetworkCheck            = "unable to check network"
 	blockRetrieval          = "unable to retrieve block"
 	balancesRetrieval       = "unable to retrieve balances"
 	oldestRetrieval         = "unable to retrieve oldest block"
@@ -140,8 +140,17 @@ func invalidNetwork(fail failure.InvalidNetwork) Error {
 	return convertError(
 		configuration.ErrorInvalidNetwork,
 		fail.Description,
-		withDetail("blockchain", fail.Blockchain),
-		withDetail("network", fail.Network),
+		withDetail("network", fail.HaveNetwork),
+		withDetail("available_networks", fail.AvailableNetworks),
+	)
+}
+
+func invalidBlockchain(fail failure.InvalidBlockchain) Error {
+	return convertError(
+		configuration.ErrorInvalidNetwork,
+		fail.Description,
+		withDetail("blockchain", fail.HaveBlockchain),
+		withDetail("available_blockchains", fail.AvailableBlockchains),
 	)
 }
 
@@ -334,6 +343,14 @@ func formatError(err error) *echo.HTTPError {
 	var icErr failure.IncompleteBlock
 	if errors.As(err, &icErr) {
 		return echo.NewHTTPError(http.StatusBadRequest, invalidFormat(icErr.Description.Text))
+	}
+	var inErr failure.InvalidNetwork
+	if errors.As(err, &inErr) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, invalidNetwork(inErr))
+	}
+	var iblErr failure.InvalidBlockchain
+	if errors.As(err, &iblErr) {
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, invalidBlockchain(iblErr))
 	}
 
 	return echo.NewHTTPError(http.StatusBadRequest, invalidFormat(err.Error()))

--- a/api/rosetta/errors.go
+++ b/api/rosetta/errors.go
@@ -326,18 +326,21 @@ func formatError(err error) *echo.HTTPError {
 	if errors.As(err, &ibErr) {
 		return echo.NewHTTPError(http.StatusBadRequest, invalidFormat(ibErr.Description.Text,
 			withDetail("want_length", ibErr.WantLength),
+			withDetail("have_length", ibErr.HaveLength),
 		))
 	}
 	var iaErr failure.InvalidAccountAddress
 	if errors.As(err, &iaErr) {
 		return echo.NewHTTPError(http.StatusBadRequest, invalidFormat(iaErr.Description.Text,
 			withDetail("want_length", iaErr.WantLength),
+			withDetail("have_length", iaErr.HaveLength),
 		))
 	}
 	var itErr failure.InvalidTransactionHash
 	if errors.As(err, &itErr) {
 		return echo.NewHTTPError(http.StatusBadRequest, invalidFormat(itErr.Description.Text,
 			withDetail("want_length", itErr.WantLength),
+			withDetail("have_length", itErr.HaveLength),
 		))
 	}
 	var icErr failure.IncompleteBlock

--- a/api/rosetta/errors.go
+++ b/api/rosetta/errors.go
@@ -44,7 +44,6 @@ const (
 	TxBodyEmpty     = "transaction text is empty"
 	SignaturesEmpty = "signature list is empty"
 
-	NetworkCheck            = "unable to check network"
 	blockRetrieval          = "unable to retrieve block"
 	balancesRetrieval       = "unable to retrieve balances"
 	oldestRetrieval         = "unable to retrieve oldest block"

--- a/api/rosetta/hash.go
+++ b/api/rosetta/hash.go
@@ -51,11 +51,6 @@ func (c *Construction) Hash(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = c.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	rosTxID, err := c.transact.TransactionIdentifier(req.SignedTransaction)
 	if err != nil {
 		return apiError(txIdentifier, err)

--- a/api/rosetta/metadata.go
+++ b/api/rosetta/metadata.go
@@ -58,11 +58,6 @@ func (c *Construction) Metadata(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = c.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	current, _, err := c.retrieve.Current()
 	if err != nil {
 		return apiError(referenceBlockRetrieval, err)

--- a/api/rosetta/options.go
+++ b/api/rosetta/options.go
@@ -62,11 +62,6 @@ func (d *Data) Options(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = d.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	// Create the allow object, which is native to the response.
 	allow := Allow{
 		OperationStatuses:       d.config.Statuses(),

--- a/api/rosetta/parse.go
+++ b/api/rosetta/parse.go
@@ -57,11 +57,6 @@ func (c *Construction) Parse(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = c.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	parse, err := c.transact.Parse(req.Transaction)
 	if err != nil {
 		return apiError(txParsing, err)

--- a/api/rosetta/payloads.go
+++ b/api/rosetta/payloads.go
@@ -64,11 +64,6 @@ func (c *Construction) Payloads(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = c.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	intent, err := c.transact.DeriveIntent(req.Operations)
 	if err != nil {
 		return apiError(intentDetermination, err)

--- a/api/rosetta/preprocess.go
+++ b/api/rosetta/preprocess.go
@@ -55,11 +55,6 @@ func (c *Construction) Preprocess(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = c.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	intent, err := c.transact.DeriveIntent(req.Operations)
 	if err != nil {
 		return apiError(intentDetermination, err)

--- a/api/rosetta/status.go
+++ b/api/rosetta/status.go
@@ -53,11 +53,6 @@ func (d *Data) Status(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = d.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	oldest, _, err := d.retrieve.Oldest()
 	if err != nil {
 		return apiError(oldestRetrieval, err)

--- a/api/rosetta/submit.go
+++ b/api/rosetta/submit.go
@@ -52,11 +52,6 @@ func (c *Construction) Submit(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = c.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	rosTxID, err := c.transact.SubmitTransaction(req.SignedTransaction)
 	if err != nil {
 		return apiError(txSubmission, err)

--- a/api/rosetta/transaction.go
+++ b/api/rosetta/transaction.go
@@ -57,11 +57,6 @@ func (d *Data) Transaction(ctx echo.Context) error {
 		return formatError(err)
 	}
 
-	err = d.config.Check(req.NetworkID)
-	if err != nil {
-		return apiError(networkCheck, err)
-	}
-
 	transaction, err := d.retrieve.Transaction(req.BlockID, req.TransactionID)
 	if err != nil {
 		return apiError(txRetrieval, err)

--- a/cmd/flow-rosetta-server/main.go
+++ b/cmd/flow-rosetta-server/main.go
@@ -134,7 +134,7 @@ func run() int {
 
 	// Rosetta API initialization.
 	config := configuration.New(params.ChainID)
-	validate := validator.New(params, index)
+	validate := validator.New(params, index, config)
 	generate := scripts.NewGenerator(params)
 	invoke, err := invoker.New(index, invoker.WithCacheSize(flagCache))
 	if err != nil {

--- a/rosetta/configuration/configuration.go
+++ b/rosetta/configuration/configuration.go
@@ -113,16 +113,16 @@ func (c *Configuration) Errors() []meta.ErrorDefinition {
 func (c *Configuration) Check(network identifier.Network) error {
 	if network.Blockchain != c.network.Blockchain {
 		return failure.InvalidBlockchain{
-			HaveBlockchain:       network.Blockchain,
-			AvailableBlockchains: c.network.Blockchain,
-			Description:          failure.NewDescription("network identifier has unknown blockchain field"),
+			HaveBlockchain: network.Blockchain,
+			WantBlockchain: c.network.Blockchain,
+			Description:    failure.NewDescription("network identifier has unknown blockchain field"),
 		}
 	}
 	if network.Network != c.network.Network {
 		return failure.InvalidNetwork{
-			HaveNetwork:       network.Network,
-			AvailableNetworks: c.network.Network,
-			Description:       failure.NewDescription("network identifier has unknown network field"),
+			HaveNetwork: network.Network,
+			WantNetwork: c.network.Network,
+			Description: failure.NewDescription("network identifier has unknown network field"),
 		}
 	}
 	return nil

--- a/rosetta/configuration/configuration.go
+++ b/rosetta/configuration/configuration.go
@@ -112,21 +112,17 @@ func (c *Configuration) Errors() []meta.ErrorDefinition {
 
 func (c *Configuration) Check(network identifier.Network) error {
 	if network.Blockchain != c.network.Blockchain {
-		return failure.InvalidNetwork{
-			Blockchain: network.Blockchain,
-			Network:    network.Network,
-			Description: failure.NewDescription("network identifier has unknown blockchain field",
-				failure.WithStrings("available_blockchains", c.network.Blockchain),
-			),
+		return failure.InvalidBlockchain{
+			HaveBlockchain:       network.Blockchain,
+			AvailableBlockchains: c.network.Blockchain,
+			Description:          failure.NewDescription("network identifier has unknown blockchain field"),
 		}
 	}
 	if network.Network != c.network.Network {
 		return failure.InvalidNetwork{
-			Blockchain: network.Blockchain,
-			Network:    network.Network,
-			Description: failure.NewDescription("network identifier has unknown network field",
-				failure.WithStrings("available_networks", c.network.Network),
-			),
+			HaveNetwork:       network.Network,
+			AvailableNetworks: c.network.Network,
+			Description:       failure.NewDescription("network identifier has unknown network field"),
 		}
 	}
 	return nil

--- a/rosetta/failure/invalid_account_address.go
+++ b/rosetta/failure/invalid_account_address.go
@@ -21,8 +21,9 @@ import (
 type InvalidAccountAddress struct {
 	Description Description
 	WantLength  int
+	HaveLength  int
 }
 
 func (i InvalidAccountAddress) Error() string {
-	return fmt.Sprintf("invalid account address length (want: %d): %s", i.WantLength, i.Description)
+	return fmt.Sprintf("invalid account address length (want: %d, have: %d): %s", i.WantLength, i.HaveLength, i.Description)
 }

--- a/rosetta/failure/invalid_block_hash.go
+++ b/rosetta/failure/invalid_block_hash.go
@@ -21,8 +21,9 @@ import (
 type InvalidBlockHash struct {
 	Description Description
 	WantLength  int
+	HaveLength  int
 }
 
 func (i InvalidBlockHash) Error() string {
-	return fmt.Sprintf("invalid block hash length (want: %d): %s", i.WantLength, i.Description)
+	return fmt.Sprintf("invalid block hash length (want: %d, have: %d): %s", i.WantLength, i.HaveLength, i.Description)
 }

--- a/rosetta/failure/invalid_blockchain.go
+++ b/rosetta/failure/invalid_blockchain.go
@@ -26,5 +26,4 @@ type InvalidBlockchain struct {
 
 func (i InvalidBlockchain) Error() string {
 	return fmt.Sprintf("invalid blockchain (have: %s, want: %s): %s", i.HaveBlockchain, i.WantBlockchain, i.Description)
-
 }

--- a/rosetta/failure/invalid_blockchain.go
+++ b/rosetta/failure/invalid_blockchain.go
@@ -19,12 +19,12 @@ import (
 )
 
 type InvalidBlockchain struct {
-	Description          Description
-	HaveBlockchain       string
-	AvailableBlockchains string
+	Description    Description
+	HaveBlockchain string
+	WantBlockchain string
 }
 
 func (i InvalidBlockchain) Error() string {
-	return fmt.Sprintf("invalid blockchain (have: %s, available: %s): %s", i.HaveBlockchain, i.AvailableBlockchains, i.Description)
+	return fmt.Sprintf("invalid blockchain (have: %s, want: %s): %s", i.HaveBlockchain, i.WantBlockchain, i.Description)
 
 }

--- a/rosetta/failure/invalid_blockchain.go
+++ b/rosetta/failure/invalid_blockchain.go
@@ -12,30 +12,19 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-package validator
+package failure
 
 import (
-	"github.com/go-playground/validator/v10"
-
-	"github.com/optakt/flow-dps/models/dps"
+	"fmt"
 )
 
-type Validator struct {
-	params   dps.Params
-	index    dps.Reader
-	config   Configuration
-	validate *validator.Validate
+type InvalidBlockchain struct {
+	Description          Description
+	HaveBlockchain       string
+	AvailableBlockchains string
 }
 
-func New(params dps.Params, index dps.Reader, config Configuration) *Validator {
+func (i InvalidBlockchain) Error() string {
+	return fmt.Sprintf("invalid blockchain (have: %s, available: %s): %s", i.HaveBlockchain, i.AvailableBlockchains, i.Description)
 
-	v := &Validator{
-		params: params,
-		index:  index,
-		config: config,
-	}
-
-	v.validate = v.newRequestValidator()
-
-	return v
 }

--- a/rosetta/failure/invalid_network.go
+++ b/rosetta/failure/invalid_network.go
@@ -19,11 +19,11 @@ import (
 )
 
 type InvalidNetwork struct {
-	Description Description
-	Blockchain  string
-	Network     string
+	Description       Description
+	HaveNetwork       string
+	AvailableNetworks string
 }
 
 func (i InvalidNetwork) Error() string {
-	return fmt.Sprintf("invalid network (blockchain: %s, network: %s): %s", i.Blockchain, i.Network, i.Description)
+	return fmt.Sprintf("invalid network (have: %s, available: %s): %s", i.HaveNetwork, i.AvailableNetworks, i.Description)
 }

--- a/rosetta/failure/invalid_network.go
+++ b/rosetta/failure/invalid_network.go
@@ -19,11 +19,11 @@ import (
 )
 
 type InvalidNetwork struct {
-	Description       Description
-	HaveNetwork       string
-	AvailableNetworks string
+	Description Description
+	HaveNetwork string
+	WantNetwork string
 }
 
 func (i InvalidNetwork) Error() string {
-	return fmt.Sprintf("invalid network (have: %s, available: %s): %s", i.HaveNetwork, i.AvailableNetworks, i.Description)
+	return fmt.Sprintf("invalid network (have: %s, want: %s): %s", i.HaveNetwork, i.WantNetwork, i.Description)
 }

--- a/rosetta/failure/invalid_transaction_hash.go
+++ b/rosetta/failure/invalid_transaction_hash.go
@@ -21,8 +21,9 @@ import (
 type InvalidTransactionHash struct {
 	Description Description
 	WantLength  int
+	HaveLength  int
 }
 
 func (i InvalidTransactionHash) Error() string {
-	return fmt.Sprintf("invalid transaction hash length (want: %d): %s", i.WantLength, i.Description)
+	return fmt.Sprintf("invalid transaction hash length (want: %d, have: %d): %s", i.WantLength, i.HaveLength, i.Description)
 }

--- a/rosetta/validator/configuration.go
+++ b/rosetta/validator/configuration.go
@@ -15,27 +15,9 @@
 package validator
 
 import (
-	"github.com/go-playground/validator/v10"
-
-	"github.com/optakt/flow-dps/models/dps"
+	"github.com/optakt/flow-dps/rosetta/identifier"
 )
 
-type Validator struct {
-	params   dps.Params
-	index    dps.Reader
-	config   Configuration
-	validate *validator.Validate
-}
-
-func New(params dps.Params, index dps.Reader, config Configuration) *Validator {
-
-	v := &Validator{
-		params: params,
-		index:  index,
-		config: config,
-	}
-
-	v.validate = v.newRequestValidator()
-
-	return v
+type Configuration interface {
+	Check(identifier.Network) error
 }

--- a/rosetta/validator/requests.go
+++ b/rosetta/validator/requests.go
@@ -41,33 +41,47 @@ const (
 	symbolField      = "symbol"
 	transactionField = "transaction"
 	signaturesField  = "signatures"
+
+	blockchainFailTag = "blockchain"
+	networkFailTag    = "network"
 )
 
-func newRequestValidator() *validator.Validate {
+// Error descriptions for common errors.
+const (
+	unknownBlockchain = "network identifier has unknown blockchain field"
+	unknownNetwork    = "network identifier has unknown network field"
+)
 
-	v := validator.New()
+func (v *Validator) newRequestValidator() *validator.Validate {
+
+	vl := validator.New()
 
 	// Register custom validators for known types.
 	// We register a single type per validator, so we can safely perform type
 	// assertion of the provided `validator.StructLevel` to the correct type.
-	v.RegisterStructValidation(blockValidator, identifier.Block{})
-	v.RegisterStructValidation(networkValidator, identifier.Network{})
-	v.RegisterStructValidation(accountValidator, identifier.Account{})
-	v.RegisterStructValidation(transactionValidator, identifier.Transaction{})
+	vl.RegisterStructValidation(blockValidator, identifier.Block{})
+	vl.RegisterStructValidation(accountValidator, identifier.Account{})
+	vl.RegisterStructValidation(transactionValidator, identifier.Transaction{})
+	vl.RegisterStructValidation(networkValidator, identifier.Network{})
+	// Validate that the request is valid for the configured network.
+	vl.RegisterStructValidation(v.netconfigValidator, identifier.Network{})
 
 	// Register custom top-level validators. These validate the entire request
 	// object, compared to the ones above which validate a specific type
 	// within the request. This way we can validate some standard types (strings)
 	// or complex ones (array of currencies) in a structured way.
-	v.RegisterStructValidation(balanceValidator, rosetta.BalanceRequest{})
-	v.RegisterStructValidation(parseValidator, rosetta.ParseRequest{})
-	v.RegisterStructValidation(combineValidator, rosetta.CombineRequest{})
-	v.RegisterStructValidation(submitValidator, rosetta.SubmitRequest{})
-	v.RegisterStructValidation(hashValidator, rosetta.HashRequest{})
+	vl.RegisterStructValidation(balanceValidator, rosetta.BalanceRequest{})
+	vl.RegisterStructValidation(parseValidator, rosetta.ParseRequest{})
+	vl.RegisterStructValidation(combineValidator, rosetta.CombineRequest{})
+	vl.RegisterStructValidation(submitValidator, rosetta.SubmitRequest{})
+	vl.RegisterStructValidation(hashValidator, rosetta.HashRequest{})
 
-	return v
+	return vl
 }
 
+// Request will run the registered validators on the provided request.
+// It will either return a typed error with contextual information, or a plain error
+// describing what failed.
 func (v *Validator) Request(request interface{}) error {
 
 	err := v.validate.Struct(request)
@@ -84,10 +98,14 @@ func (v *Validator) Request(request interface{}) error {
 	}
 
 	// Process validation errors we have found. Return the first one we encounter.
-	errs := err.(validator.ValidationErrors)
-	msg := errs[0].Tag()
+	// Validator library doesn't offer a sophisticated mechanism for passing detailed
+	// error information from the lower validation layers, so we use the `tag` field
+	// to identify what went wrong.
+	// In the case of blockchain/network misconfigurtion, we also use the `param` field
+	// to pass the acceptable value for the field.
+	verr := err.(validator.ValidationErrors)[0]
 
-	switch msg {
+	switch verr.Tag() {
 	case rosetta.BlockLength:
 		return failure.InvalidBlockHash{
 			Description: failure.NewDescription(rosetta.BlockLength),
@@ -106,18 +124,51 @@ func (v *Validator) Request(request interface{}) error {
 			WantLength:  rosetta.HexIDSize,
 		}
 
+	case networkFailTag:
+		// Network field is not referring to the network for which we are configured.
+		network, _ := verr.Value().(identifier.Network)
+		return failure.InvalidNetwork{
+			HaveNetwork:       network.Network,
+			AvailableNetworks: verr.Param(),
+			Description:       failure.NewDescription(unknownNetwork),
+		}
+
+	case blockchainFailTag:
+		// Blockchain field is not referring to the blockchain for which we are configured.
+		network, _ := verr.Value().(identifier.Network)
+		return failure.InvalidBlockchain{
+			HaveBlockchain:       network.Blockchain,
+			AvailableBlockchains: verr.Param(),
+			Description:          failure.NewDescription(unknownBlockchain),
+		}
+
 	default:
-		return fmt.Errorf(msg)
+		return fmt.Errorf(verr.Tag())
 	}
 }
 
-func blockValidator(sl validator.StructLevel) {
-	rosBlockID := sl.Current().Interface().(identifier.Block)
-	if rosBlockID.Hash != "" && len(rosBlockID.Hash) != rosetta.HexIDSize {
-		sl.ReportError(rosBlockID.Hash, blockHashField, blockHashField, rosetta.BlockLength, "")
+// netconfigValidator verifies that the request is valid for the configured network.
+// Network and blockchain identifier may be correctly populated, but invalid for the
+// current running instance of the DPS - e.g. addressing a Testnet network while we
+// have Mainnet network data.
+func (v *Validator) netconfigValidator(sl validator.StructLevel) {
+	network := sl.Current().Interface().(identifier.Network)
+
+	err := v.config.Check(network)
+	// Check returns a typed error, which we can use to identify which field was invalid.
+	// We will use `tag` field to communicate this, and the `param` field to pass the acceptable
+	// value to the main validation function.
+	var ibErr failure.InvalidBlockchain
+	if errors.As(err, &ibErr) {
+		sl.ReportError(network, blockchainField, blockchainField, blockchainFailTag, ibErr.AvailableBlockchains)
+	}
+	var inErr failure.InvalidNetwork
+	if errors.As(err, &inErr) {
+		sl.ReportError(network, networkField, networkField, networkFailTag, inErr.AvailableNetworks)
 	}
 }
 
+// networkValidator ensures that the blockchain and network fields are populated.
 func networkValidator(sl validator.StructLevel) {
 	network := sl.Current().Interface().(identifier.Network)
 	if network.Blockchain == "" {
@@ -128,6 +179,15 @@ func networkValidator(sl validator.StructLevel) {
 	}
 }
 
+// blockValidator ensures that, if the block hash is provided, it has the correct length.
+func blockValidator(sl validator.StructLevel) {
+	rosBlockID := sl.Current().Interface().(identifier.Block)
+	if rosBlockID.Hash != "" && len(rosBlockID.Hash) != rosetta.HexIDSize {
+		sl.ReportError(rosBlockID.Hash, blockHashField, blockHashField, rosetta.BlockLength, "")
+	}
+}
+
+// accountValidator ensures that the account address field is populated and has correct length.
 func accountValidator(sl validator.StructLevel) {
 	rosAccountID := sl.Current().Interface().(identifier.Account)
 	if rosAccountID.Address == "" {
@@ -138,6 +198,7 @@ func accountValidator(sl validator.StructLevel) {
 	}
 }
 
+// transactionValidator ensures that the transaction identifier is populated and has correct length.
 func transactionValidator(sl validator.StructLevel) {
 	rosTxID := sl.Current().Interface().(identifier.Transaction)
 	if rosTxID.Hash == "" {
@@ -148,6 +209,8 @@ func transactionValidator(sl validator.StructLevel) {
 	}
 }
 
+// balanceValidator ensures that the provided BalanceRequest has a non-empty currency list, and that
+// all provided currencies have the `symbol` field populated.
 func balanceValidator(sl validator.StructLevel) {
 	req := sl.Current().Interface().(rosetta.BalanceRequest)
 	if len(req.Currencies) == 0 {
@@ -160,6 +223,7 @@ func balanceValidator(sl validator.StructLevel) {
 	}
 }
 
+// parseValidator ensures that the provided ParseRequest has a non-empty transaction field.
 func parseValidator(sl validator.StructLevel) {
 	req := sl.Current().Interface().(rosetta.ParseRequest)
 	if req.Transaction == "" {
@@ -167,6 +231,8 @@ func parseValidator(sl validator.StructLevel) {
 	}
 }
 
+// combineValidator ensures that the provided CombineRequest has a non-empty transaction field, and
+// that the signature list is not empty.
 func combineValidator(sl validator.StructLevel) {
 	req := sl.Current().Interface().(rosetta.CombineRequest)
 	if req.UnsignedTransaction == "" {
@@ -178,6 +244,7 @@ func combineValidator(sl validator.StructLevel) {
 	}
 }
 
+// submitValidator ensures that the provided SubmitRequest has a non-empty transaction field.
 func submitValidator(sl validator.StructLevel) {
 	req := sl.Current().Interface().(rosetta.SubmitRequest)
 	if req.SignedTransaction == "" {
@@ -185,6 +252,7 @@ func submitValidator(sl validator.StructLevel) {
 	}
 }
 
+// hashValidator ensures that the provided SubmitRequest has a non-empty transaction field.
 func hashValidator(sl validator.StructLevel) {
 	req := sl.Current().Interface().(rosetta.HashRequest)
 	if req.SignedTransaction == "" {

--- a/rosetta/validator/requests.go
+++ b/rosetta/validator/requests.go
@@ -138,18 +138,18 @@ func (v *Validator) Request(request interface{}) error {
 		// Network field is not referring to the network for which we are configured.
 		network, _ := verr.Value().(identifier.Network)
 		return failure.InvalidNetwork{
-			HaveNetwork:       network.Network,
-			AvailableNetworks: verr.Param(),
-			Description:       failure.NewDescription(unknownNetwork),
+			HaveNetwork: network.Network,
+			WantNetwork: verr.Param(),
+			Description: failure.NewDescription(unknownNetwork),
 		}
 
 	case blockchainFailTag:
 		// Blockchain field is not referring to the blockchain for which we are configured.
 		network, _ := verr.Value().(identifier.Network)
 		return failure.InvalidBlockchain{
-			HaveBlockchain:       network.Blockchain,
-			AvailableBlockchains: verr.Param(),
-			Description:          failure.NewDescription(unknownBlockchain),
+			HaveBlockchain: network.Blockchain,
+			WantBlockchain: verr.Param(),
+			Description:    failure.NewDescription(unknownBlockchain),
 		}
 
 	default:
@@ -177,11 +177,11 @@ func (v *Validator) networkValidator(sl validator.StructLevel) {
 	// value to the main validation function.
 	var ibErr failure.InvalidBlockchain
 	if errors.As(err, &ibErr) {
-		sl.ReportError(network, blockchainField, blockchainField, blockchainFailTag, ibErr.AvailableBlockchains)
+		sl.ReportError(network, blockchainField, blockchainField, blockchainFailTag, ibErr.WantBlockchain)
 	}
 	var inErr failure.InvalidNetwork
 	if errors.As(err, &inErr) {
-		sl.ReportError(network, networkField, networkField, networkFailTag, inErr.AvailableNetworks)
+		sl.ReportError(network, networkField, networkField, networkFailTag, inErr.WantNetwork)
 	}
 }
 

--- a/rosetta/validator/requests.go
+++ b/rosetta/validator/requests.go
@@ -108,21 +108,30 @@ func (v *Validator) Request(request interface{}) error {
 
 	switch verr.Tag() {
 	case rosetta.BlockLength:
+		// Block hash has incorrect length.
+		blockHash, _ := verr.Value().(string)
 		return failure.InvalidBlockHash{
 			Description: failure.NewDescription(rosetta.BlockLength),
 			WantLength:  rosetta.HexIDSize,
+			HaveLength:  len(blockHash),
 		}
 
 	case rosetta.AddressLength:
+		// Account address has incorrect length.
+		address, _ := verr.Value().(string)
 		return failure.InvalidAccountAddress{
 			Description: failure.NewDescription(rosetta.AddressLength),
 			WantLength:  rosetta.HexAddressSize,
+			HaveLength:  len(address),
 		}
 
 	case rosetta.TxLength:
+		// Transaction hash has incorrect length.
+		txHash, _ := verr.Value().(string)
 		return failure.InvalidTransactionHash{
 			Description: failure.NewDescription(rosetta.TxLength),
 			WantLength:  rosetta.HexIDSize,
+			HaveLength:  len(txHash),
 		}
 
 	case networkFailTag:

--- a/rosetta/validator/validator.go
+++ b/rosetta/validator/validator.go
@@ -23,19 +23,16 @@ import (
 type Validator struct {
 	params   dps.Params
 	index    dps.Reader
-	config   Configuration
 	validate *validator.Validate
 }
 
 func New(params dps.Params, index dps.Reader, config Configuration) *Validator {
 
 	v := &Validator{
-		params: params,
-		index:  index,
-		config: config,
+		params:   params,
+		index:    index,
+		validate: newRequestValidator(config),
 	}
-
-	v.validate = v.newRequestValidator()
 
 	return v
 }


### PR DESCRIPTION
## Goal of this PR

Fixes #429.

This PR moves the network identifier validation code from the Rosetta API package to the validator package.
I also found a way how to nicely reintroduce the `have_length` contextual information for hashes/addresses that have incorrect lengths.

The `InvalidNetwork` error no longer means `invalid network or invalid blockchain field`, but instead only means the former. For the latter I introduced the `InvalidBlockchain` error to allow for more granular control and identifying what exactly was wrong.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date