### PR TITLE
Use option in `zbor` and GCP streamer for CBOR decoding

### DIFF
--- a/docs/dps-api.md
+++ b/docs/dps-api.md
@@ -111,10 +111,10 @@ Here is an example of how to decode this field in a small Go program:
 
 ```go
    var header flow.Header
-err := cbor.Unmarshal(response.Data, &header)
-if err != nil {
-return err
-}
+   err := cbor.Unmarshal(response.Data, &header)
+   if err != nil {
+        return err
+   }
 ```
 
 ### GetEventsRequest
@@ -138,10 +138,10 @@ Here is an example of how to decode this field in a small Go program:
 
 ```go
    var events []flow.Event
-err := cbor.Unmarshal(response.Data, &events)
-if err != nil {
-return err
-}
+   err := cbor.Unmarshal(response.Data, &events)
+   if err != nil {
+        return err
+   }
 ```
 
 ### GetTransactionRequest

--- a/service/cloud/gcp_streamer_internal_test.go
+++ b/service/cloud/gcp_streamer_internal_test.go
@@ -68,6 +68,10 @@ func TestGCPStreamer_Next(t *testing.T) {
 	data, err := cbor.Marshal(record)
 	require.NoError(t, err)
 
+	decOptions := cbor.DecOptions{ExtraReturnErrors: cbor.ExtraDecErrorUnknownField}
+	decoder, err := decOptions.DecMode()
+	require.NoError(t, err)
+
 	t.Run("returns available record if buffer not empty", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 			rw.WriteHeader(http.StatusOK)
@@ -82,11 +86,12 @@ func TestGCPStreamer_Next(t *testing.T) {
 		bucket := client.Bucket("test")
 
 		streamer := &GCPStreamer{
-			log:    zerolog.Nop(),
-			bucket: bucket,
-			queue:  dps.NewDeque(),
-			buffer: dps.NewDeque(),
-			limit:  999,
+			log:     zerolog.Nop(),
+			bucket:  bucket,
+			decoder: decoder,
+			queue:   dps.NewDeque(),
+			buffer:  dps.NewDeque(),
+			limit:   999,
 		}
 
 		streamer.buffer.PushFront(record)
@@ -111,11 +116,12 @@ func TestGCPStreamer_Next(t *testing.T) {
 		bucket := client.Bucket("test")
 
 		streamer := &GCPStreamer{
-			log:    zerolog.Nop(),
-			bucket: bucket,
-			queue:  dps.NewDeque(),
-			buffer: dps.NewDeque(),
-			limit:  999,
+			log:     zerolog.Nop(),
+			bucket:  bucket,
+			decoder: decoder,
+			queue:   dps.NewDeque(),
+			buffer:  dps.NewDeque(),
+			limit:   999,
 		}
 
 		_, err = streamer.Next()
@@ -140,11 +146,12 @@ func TestGCPStreamer_Next(t *testing.T) {
 		bucket := client.Bucket("test")
 
 		streamer := &GCPStreamer{
-			log:    zerolog.Nop(),
-			bucket: bucket,
-			queue:  dps.NewDeque(),
-			buffer: dps.NewDeque(),
-			limit:  999,
+			log:     zerolog.Nop(),
+			bucket:  bucket,
+			decoder: decoder,
+			queue:   dps.NewDeque(),
+			buffer:  dps.NewDeque(),
+			limit:   999,
 		}
 
 		streamer.queue.PushFront(record.Block.ID())


### PR DESCRIPTION
## Goal of this PR

Fixes #413 

## Additional Notes

I took a look at all the decoding options and none other seem interesting to me, but here's the overview if you're curious. LMK if you think some others would make sense to specify as well:

```go
// DecOptions specifies decoding options.
type DecOptions struct {
	// DupMapKey specifies whether to enforce duplicate map key.
	DupMapKey DupMapKeyMode

	// TimeTag specifies whether to check validity of time.Time (e.g. valid tag number and tag content type).
	// For now, valid tag number means 0 or 1 as specified in RFC 7049 if the Go type is time.Time.
	TimeTag DecTagMode

	// MaxNestedLevels specifies the max nested levels allowed for any combination of CBOR array, maps, and tags.
	// Default is 32 levels and it can be set to [4, 32767].
	MaxNestedLevels int

	// MaxArrayElements specifies the max number of elements for CBOR arrays.
	// Default is 128*1024=131072 and it can be set to [16, 2147483647] on 32-bit arch
	// or [16, 9223372036854775807] on 64-bit arch.
	MaxArrayElements int

	// MaxMapPairs specifies the max number of key-value pairs for CBOR maps.
	// Default is 128*1024=131072 and it can be set to [16, 2147483647] on 32-bit arch
	// or [16, 9223372036854775807] on 64-bit arch.
	MaxMapPairs int

	// IndefLength specifies whether to allow indefinite length CBOR items.
	IndefLength IndefLengthMode

	// TagsMd specifies whether to allow CBOR tags (major type 6).
	TagsMd TagsMode

	// IntDec specifies which Go integer type (int64 or uint64) to use
	// when decoding CBOR int (major type 0 and 1) to Go interface{}.
	IntDec IntDecMode

	// ExtraReturnErrors specifies extra conditions that should be treated as errors.
	ExtraReturnErrors ExtraDecErrorCond
}
```

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date