### PR TITLE
Add sanity check for mismatch in execution state

### DIFF
--- a/cmd/flow-dps-indexer/main.go
+++ b/cmd/flow-dps-indexer/main.go
@@ -180,6 +180,7 @@ func run() int {
 		mapper.WithTransition(mapper.StatusUpdate, transitions.UpdateTree),
 		mapper.WithTransition(mapper.StatusCollect, transitions.CollectRegisters),
 		mapper.WithTransition(mapper.StatusMap, transitions.MapRegisters),
+		mapper.WithTransition(mapper.StatusCheck, transitions.CheckSeals),
 		mapper.WithTransition(mapper.StatusForward, transitions.ForwardHeight),
 	)
 

--- a/cmd/flow-dps-live/main.go
+++ b/cmd/flow-dps-live/main.go
@@ -330,6 +330,7 @@ func run() int {
 		mapper.WithTransition(mapper.StatusUpdate, transitions.UpdateTree),
 		mapper.WithTransition(mapper.StatusCollect, transitions.CollectRegisters),
 		mapper.WithTransition(mapper.StatusMap, transitions.MapRegisters),
+		mapper.WithTransition(mapper.StatusCheck, transitions.CheckSeals),
 		mapper.WithTransition(mapper.StatusForward, transitions.ForwardHeight),
 	)
 

--- a/service/mapper/status.go
+++ b/service/mapper/status.go
@@ -27,6 +27,7 @@ const (
 	StatusUpdate
 	StatusCollect
 	StatusMap
+	StatusCheck
 	StatusForward
 )
 
@@ -45,6 +46,8 @@ func (s Status) String() string {
 		return "collect"
 	case StatusMap:
 		return "map"
+	case StatusCheck:
+		return "check"
 	case StatusForward:
 		return "forward"
 	default:

--- a/service/mapper/transitions.go
+++ b/service/mapper/transitions.go
@@ -442,7 +442,7 @@ func (t *Transitions) MapRegisters(s *State) error {
 	// which is about forwarding the height to the next finalized block.
 	if len(s.registers) == 0 {
 		log.Info().Msg("indexed all registers for finalized block")
-		s.status = StatusForward
+		s.status = StatusCheck
 		return nil
 	}
 
@@ -470,6 +470,48 @@ func (t *Transitions) MapRegisters(s *State) error {
 
 	log.Debug().Int("batch", len(paths)).Int("remaining", len(s.registers)).Msg("indexed register batch for finalized block")
 
+	return nil
+}
+
+// CheckSeals runs a sanity check by comparing the seals of the latest block with the previously indexed state
+// commitments.
+func (t *Transitions) CheckSeals(s *State) error {
+	if s.status != StatusCheck {
+		return fmt.Errorf("invalid status for sanity checking seals (%s)", s.status)
+	}
+
+	// List all indexed seals at the current height.
+	sealIDs, err := t.read.SealsByHeight(s.height)
+	if err != nil {
+		return fmt.Errorf("could not list seals: %w", err)
+	}
+
+	// Compare each seal's final state with the previously indexed state commitments.
+	// If a mismatch occurs, it means that the wrong execution result was computed
+	// by the blockchain at some point, and that we should crash.
+	for _, sealID := range sealIDs {
+		seal, err := t.read.Seal(sealID)
+		if err != nil {
+			return fmt.Errorf("could not retrieve seal: %w", err)
+		}
+
+		height, err := t.read.HeightForBlock(seal.BlockID)
+		if err != nil {
+			return fmt.Errorf("could not retrieve height for block: %w", err)
+		}
+
+		commit, err := t.read.Commit(height)
+		if err != nil {
+			return fmt.Errorf("could not retrieve commit for height: %w", err)
+		}
+
+		if seal.FinalState != commit {
+			return fmt.Errorf("execution state mismatch at height %d", height)
+		}
+	}
+
+	// No mismatch was detected, we can forward to the next height.
+	s.status = StatusForward
 	return nil
 }
 

--- a/service/tracker/execution_internal_test.go
+++ b/service/tracker/execution_internal_test.go
@@ -248,12 +248,6 @@ func BaselineExecution(t *testing.T, opts ...func(*Execution)) *Execution {
 	return &e
 }
 
-func WithLogger(log zerolog.Logger) func(*Execution) {
-	return func(execution *Execution) {
-		execution.log = log
-	}
-}
-
 func WithStreamer(stream RecordStreamer) func(*Execution) {
 	return func(execution *Execution) {
 		execution.stream = stream


### PR DESCRIPTION
## Goal of this PR

Fixes #395 

## Additional Notes

* This PR does not test the case where a mismatch occurs, since we can't test code that calls `log.Fatal()` without making a wrapper around zerolog logger and using that everywhere.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date