### PR TITLE
Change index writer to always flush DB transactions

### DIFF
--- a/cmd/flow-dps-live/README.md
+++ b/cmd/flow-dps-live/README.md
@@ -19,7 +19,7 @@ Usage of flow-dps-live:
   -i, --index string              path to database directory for state index (default "index")
   -l, --level string              log output level (default "info")
   -s, --skip                      skip indexing of execution state ledger registers
-      --flush-interval duration   idle time before flushing badger transactions (default 1s)
+      --flush-interval duration   interval for flushing badger transactions (0s for disabled)
       --seed-address string       host address of seed node to follow consensus
       --seed-key string           hex-encoded public network key of seed node to follow consensus
 

--- a/cmd/flow-dps-live/main.go
+++ b/cmd/flow-dps-live/main.go
@@ -98,7 +98,7 @@ func run() int {
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
 	pflag.BoolVarP(&flagSkip, "skip", "s", false, "skip indexing of execution state ledger registers")
 
-	pflag.DurationVar(&flagFlushInterval, "flush-interval", 1*time.Second, "idle time before flushing badger transactions")
+	pflag.DurationVar(&flagFlushInterval, "flush-interval", 1*time.Second, "interval for flushing badger transactions (0s for disabled)")
 	pflag.StringVar(&flagSeedAddress, "seed-address", "", "host address of seed node to follow consensus")
 	pflag.StringVar(&flagSeedKey, "seed-key", "", "hex-encoded public network key of seed node to follow consensus")
 
@@ -167,6 +167,12 @@ func run() int {
 		log.Error().Msg("index already exists, please force bootstrapping (-f, --force) to overwrite with given checkpoint")
 		return failure
 	}
+
+	// We initialize the writer with a flush interval, which will make sure that
+	// Badger transactions are committed to the database, even if they don't
+	// fill up fast enough. This avoids having latency between when we add data
+	// to the transaction and when it becomes available on-disk for serving the
+	// DPS API.
 	write := index.NewWriter(indexDB, storage,
 		index.WithFlushInterval(flagFlushInterval),
 	)

--- a/service/index/config.go
+++ b/service/index/config.go
@@ -39,7 +39,8 @@ func WithConcurrentTransactions(concurrent uint) func(*Config) {
 }
 
 // WithFlushInterval sets a custom interval after which we will flush Badger
-// transactions if no new operations are added.
+// transactions, to avoid long waits for DB updates in cases where there is not
+// enough data to quickly fill them.
 func WithFlushInterval(interval time.Duration) func(*Config) {
 	return func(cfg *Config) {
 		cfg.FlushInterval = interval

--- a/service/index/writer.go
+++ b/service/index/writer.go
@@ -341,8 +341,8 @@ func (w *Writer) flush() {
 	defer w.wg.Done()
 
 	ticker := time.NewTicker(w.cfg.FlushInterval)
+	defer ticker.Stop()
 
-FlushLoop:
 	for {
 		select {
 
@@ -354,9 +354,7 @@ FlushLoop:
 			w.mutex.Unlock()
 
 		case <-w.done:
-			break FlushLoop
+			return
 		}
 	}
-
-	ticker.Stop()
 }

--- a/service/index/writer.go
+++ b/service/index/writer.go
@@ -307,7 +307,7 @@ func (w *Writer) Close() error {
 	// transactions. The currently building transaction is not in-progress.
 	// However, we still need to make sure that the currently building
 	// transaction is properly committed. We assume that we are no longer
-	// appyling new operations when we call `Close`, so we can explicitly do so
+	// applying new operations when we call `Close`, so we can explicitly do so
 	// here, without using the callback.
 	err := w.tx.Commit()
 	if err != nil {


### PR DESCRIPTION
## Goal of this PR

This PR makes sure that we always flush the DB transactions at regular intervals, even when not idle. This will make sure that we don't stop flushing when blocks are faster than expected, and that there is no latency for data to become available in the DB.

Flushing is always disabled for the past spork indexer, and enabled with a default setting for the live indexer.

Fixes #477.