### PR TITLE
Add tests for the index-based trie loader

### DIFF
--- a/service/loader/checkpoint_test.go
+++ b/service/loader/checkpoint_test.go
@@ -1,0 +1,63 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package loader_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/ledger/complete/mtrie/flattener"
+	"github.com/onflow/flow-go/ledger/complete/wal"
+
+	"github.com/optakt/flow-dps/service/loader"
+	"github.com/optakt/flow-dps/testing/mocks"
+)
+
+func TestLoader_FromCheckpoint(t *testing.T) {
+
+	t.Run("handles failure to read checkpoint", func(t *testing.T) {
+
+		reader := bytes.NewReader(mocks.GenericBytes)
+		load := loader.FromCheckpoint(reader)
+
+		_, err := load.Trie()
+		require.Error(t, err)
+	})
+
+	t.Run("handles failure to rebuild tries", func(t *testing.T) {
+
+		forest := &flattener.FlattenedForest{
+			Nodes: []*flattener.StorableNode{
+				{},
+			},
+			Tries: []*flattener.StorableTrie{
+				{},
+			},
+		}
+
+		buffer := bytes.Buffer{}
+		err := wal.StoreCheckpoint(forest, &buffer)
+		require.NoError(t, err)
+
+		checkpoint := bytes.NewReader(buffer.Bytes())
+
+		load := loader.FromCheckpoint(checkpoint)
+
+		_, err = load.Trie()
+		require.Error(t, err)
+	})
+}

--- a/service/loader/config.go
+++ b/service/loader/config.go
@@ -28,7 +28,7 @@ var DefaultConfig = Config{
 // Config contains the configuration options for the index loader.
 type Config struct {
 	TrieInitializer mapper.Loader
-	ExcludeHeight   func(uint64) bool
+	ExcludeHeight   Exclude
 }
 
 // Option is a configuration option for the index loader. It can be passed to

--- a/service/loader/config_internal_test.go
+++ b/service/loader/config_internal_test.go
@@ -32,6 +32,9 @@ func TestWithTrieInitializer(t *testing.T) {
 }
 
 func TestWithExclude(t *testing.T) {
+	// In Go, the only valid comparison for functions is with nil.
+	// Thus we will set ExcludeHeight to nil so we can later verify
+	// that it was correctly initialized.
 	c := Config{
 		ExcludeHeight: nil,
 	}

--- a/service/loader/config_internal_test.go
+++ b/service/loader/config_internal_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWithTrieInitializer(t *testing.T) {
+func TestLoader_WithTrieInitializer(t *testing.T) {
 	c := Config{
 		TrieInitializer: FromCheckpoint(os.Stdin),
 	}
@@ -31,7 +31,7 @@ func TestWithTrieInitializer(t *testing.T) {
 	assert.Equal(t, trieInitializer, c.TrieInitializer)
 }
 
-func TestWithExclude(t *testing.T) {
+func TestLoader_WithExclude(t *testing.T) {
 	// In Go, the only valid comparison for functions is with nil.
 	// Thus we will set ExcludeHeight to nil so we can later verify
 	// that it was correctly initialized.

--- a/service/loader/config_internal_test.go
+++ b/service/loader/config_internal_test.go
@@ -1,0 +1,42 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package loader
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithTrieInitializer(t *testing.T) {
+	c := Config{
+		TrieInitializer: FromCheckpoint(os.Stdin),
+	}
+	trieInitializer := FromScratch()
+
+	WithInitializer(trieInitializer)(&c)
+	assert.Equal(t, trieInitializer, c.TrieInitializer)
+}
+
+func TestWithExclude(t *testing.T) {
+	c := Config{
+		ExcludeHeight: nil,
+	}
+	excluder := ExcludeNone()
+
+	WithExclude(excluder)(&c)
+	assert.NotNil(t, c.ExcludeHeight)
+}

--- a/service/loader/empty_test.go
+++ b/service/loader/empty_test.go
@@ -24,13 +24,11 @@ import (
 )
 
 func TestLoader_FromScratch(t *testing.T) {
-	t.Run("nominal case", func(t *testing.T) {
-		t.Parallel()
+	t.Parallel()
 
-		empty := loader.FromScratch()
+	empty := loader.FromScratch()
 
-		trie, err := empty.Trie()
-		require.NoError(t, err)
-		assert.True(t, trie.IsEmpty())
-	})
+	trie, err := empty.Trie()
+	require.NoError(t, err)
+	assert.True(t, trie.IsEmpty())
 }

--- a/service/loader/empty_test.go
+++ b/service/loader/empty_test.go
@@ -1,0 +1,36 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package loader_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/optakt/flow-dps/service/loader"
+)
+
+func TestFromScratch(t *testing.T) {
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		empty := loader.FromScratch()
+
+		trie, err := empty.Trie()
+		require.NoError(t, err)
+		assert.True(t, trie.IsEmpty())
+	})
+}

--- a/service/loader/empty_test.go
+++ b/service/loader/empty_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/optakt/flow-dps/service/loader"
 )
 
-func TestFromScratch(t *testing.T) {
+func TestLoader_FromScratch(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 

--- a/service/loader/index_test.go
+++ b/service/loader/index_test.go
@@ -1,0 +1,103 @@
+// Copyright 2021 Optakt Labs OÜ
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+package loader_test
+
+import (
+	"testing"
+
+	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/optakt/flow-dps/codec/zbor"
+	"github.com/optakt/flow-dps/service/loader"
+	"github.com/optakt/flow-dps/service/storage"
+	"github.com/optakt/flow-dps/testing/helpers"
+	"github.com/optakt/flow-dps/testing/mocks"
+)
+
+func TestFromIndex_Trie(t *testing.T) {
+	entries := 5
+	paths := mocks.GenericLedgerPaths(entries)
+	payloads := mocks.GenericLedgerPayloads(entries)
+
+	t.Run("nominal case", func(t *testing.T) {
+		t.Parallel()
+
+		log := zerolog.Nop()
+		codec := zbor.NewCodec()
+		storage := storage.New(codec)
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
+
+		for i := 0; i < entries; i++ {
+			height := mocks.GenericHeight + uint64(i)
+			require.NoError(t, db.Update(storage.SavePayload(height, paths[i], payloads[i])))
+		}
+
+		load := loader.FromIndex(log, storage, db)
+
+		trie, err := load.Trie()
+		require.NoError(t, err)
+		assert.True(t, trie.IsAValidTrie())
+	})
+
+	t.Run("handles failure to initialize trie", func(t *testing.T) {
+		t.Parallel()
+
+		log := zerolog.Nop()
+		codec := zbor.NewCodec()
+		storage := storage.New(codec)
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
+
+		initializer := mocks.BaselineLoader(t)
+		initializer.TrieFunc = func() (*trie.MTrie, error) {
+			return nil, mocks.GenericError
+		}
+
+		load := loader.FromIndex(log, storage, db, loader.WithInitializer(initializer))
+
+		_, err := load.Trie()
+		require.Error(t, err)
+	})
+
+	t.Run("handles failure to iterate ledger", func(t *testing.T) {
+		t.Parallel()
+
+		log := zerolog.Nop()
+		codec := mocks.BaselineCodec(t)
+		codec.UnmarshalFunc = func([]byte, interface{}) error {
+			return mocks.GenericError
+		}
+		storage := storage.New(codec)
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
+
+		for i := 0; i < entries; i++ {
+			height := mocks.GenericHeight + uint64(i)
+			require.NoError(t, db.Update(storage.SavePayload(height, paths[i], payloads[i])))
+		}
+
+		load := loader.FromIndex(log, storage, db)
+
+		_, err := load.Trie()
+		require.Error(t, err)
+	})
+}

--- a/service/loader/index_test.go
+++ b/service/loader/index_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/optakt/flow-dps/testing/mocks"
 )
 
-func TestFromIndex_Trie(t *testing.T) {
+func TestLoader_FromIndex(t *testing.T) {
 	entries := 5
 	paths := mocks.GenericLedgerPaths(entries)
 	payloads := mocks.GenericLedgerPayloads(entries)

--- a/service/loader/index_test.go
+++ b/service/loader/index_test.go
@@ -17,10 +17,11 @@ package loader_test
 import (
 	"testing"
 
-	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 
 	"github.com/optakt/flow-dps/codec/zbor"
 	"github.com/optakt/flow-dps/service/loader"

--- a/service/storage/operations_internal_test.go
+++ b/service/storage/operations_internal_test.go
@@ -239,9 +239,6 @@ func TestLibrary_SaveAndRetrieveEvents(t *testing.T) {
 	t.Run("save multiple events under different types", func(t *testing.T) {
 		t.Parallel()
 
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		testEvents1 := []flow.Event{
 			{Type: mocks.GenericEventType(0)},
 			{Type: mocks.GenericEventType(0)},
@@ -262,6 +259,9 @@ func TestLibrary_SaveAndRetrieveEvents(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.SaveEvents(mocks.GenericHeight, mocks.GenericEventType(0), testEvents1))
 		assert.NoError(t, err)
@@ -430,9 +430,6 @@ func TestLibrary_SaveAndRetrievePayload(t *testing.T) {
 	t.Run("save two different payloads for same path at different heights", func(t *testing.T) {
 		t.Parallel()
 
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, &ledger.Payload{}, v)
@@ -442,6 +439,9 @@ func TestLibrary_SaveAndRetrievePayload(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.SavePayload(mocks.GenericHeight, mocks.GenericLedgerPath(0), mocks.GenericLedgerPayload(0)))
 		assert.NoError(t, err)
@@ -689,9 +689,6 @@ func TestLibrary_IndexAndLookupHeightForBlock(t *testing.T) {
 	t.Run("save height of block", func(t *testing.T) {
 		t.Parallel()
 
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, uint64(0), v)
@@ -701,6 +698,9 @@ func TestLibrary_IndexAndLookupHeightForBlock(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.IndexHeightForBlock(blockID, mocks.GenericHeight))
 
@@ -747,9 +747,6 @@ func TestSaveAndRetrieve_Transaction(t *testing.T) {
 	t.Run("save transaction", func(t *testing.T) {
 		t.Parallel()
 
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, &flow.TransactionBody{}, v)
@@ -759,6 +756,9 @@ func TestSaveAndRetrieve_Transaction(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.SaveTransaction(tx))
 
@@ -805,9 +805,6 @@ func TestLibrary_IndexAndLookupHeightForTransaction(t *testing.T) {
 	t.Run("save height of transaction", func(t *testing.T) {
 		t.Parallel()
 
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, uint64(0), v)
@@ -817,6 +814,9 @@ func TestLibrary_IndexAndLookupHeightForTransaction(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.IndexHeightForTransaction(txID, mocks.GenericHeight))
 
@@ -862,9 +862,6 @@ func TestIndexAndLookup_TransactionsForHeight(t *testing.T) {
 	t.Run("save transactions", func(t *testing.T) {
 		t.Parallel()
 
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, []flow.Identifier{}, v)
@@ -874,6 +871,9 @@ func TestIndexAndLookup_TransactionsForHeight(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.IndexTransactionsForHeight(mocks.GenericHeight, mocks.GenericTransactionIDs(5)))
 
@@ -919,10 +919,6 @@ func TestSaveAndRetrieve_Collection(t *testing.T) {
 
 	t.Run("save collection", func(t *testing.T) {
 		t.Parallel()
-
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, &flow.LightCollection{}, v)
@@ -932,6 +928,9 @@ func TestSaveAndRetrieve_Collection(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.SaveCollection(collection))
 
@@ -977,10 +976,6 @@ func TestSaveAndRetrieve_Guarantee(t *testing.T) {
 
 	t.Run("save guarantee", func(t *testing.T) {
 		t.Parallel()
-
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, &flow.CollectionGuarantee{}, v)
@@ -990,6 +985,9 @@ func TestSaveAndRetrieve_Guarantee(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.SaveGuarantee(guarantee))
 
@@ -1035,10 +1033,6 @@ func TestIndexAndLookup_CollectionsForHeight(t *testing.T) {
 
 	t.Run("save collections", func(t *testing.T) {
 		t.Parallel()
-
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, []flow.Identifier{}, v)
@@ -1048,6 +1042,9 @@ func TestIndexAndLookup_CollectionsForHeight(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.IndexCollectionsForHeight(mocks.GenericHeight, collIDs))
 
@@ -1092,10 +1089,6 @@ func TestSaveAndRetrieve_TransactionResults(t *testing.T) {
 
 	t.Run("save transaction result", func(t *testing.T) {
 		t.Parallel()
-
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, &flow.TransactionResult{}, v)
@@ -1105,6 +1098,9 @@ func TestSaveAndRetrieve_TransactionResults(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.SaveResult(mocks.GenericResult(0)))
 
@@ -1150,10 +1146,6 @@ func TestSaveAndRetrieve_Seal(t *testing.T) {
 
 	t.Run("save seal", func(t *testing.T) {
 		t.Parallel()
-
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, &flow.Seal{}, v)
@@ -1163,6 +1155,9 @@ func TestSaveAndRetrieve_Seal(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.SaveSeal(seal))
 
@@ -1208,9 +1203,6 @@ func TestIndexAndLookup_Seals(t *testing.T) {
 	t.Run("save seals", func(t *testing.T) {
 		t.Parallel()
 
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, []flow.Identifier{}, v)
@@ -1220,6 +1212,9 @@ func TestIndexAndLookup_Seals(t *testing.T) {
 		l := &Library{
 			codec: codec,
 		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		err := db.Update(l.IndexSealsForHeight(mocks.GenericHeight, mocks.GenericSealIDs(5)))
 		assert.NoError(t, err)
@@ -1266,11 +1261,13 @@ func TestLibrary_IterateLedger(t *testing.T) {
 	t.Run("nominal case", func(t *testing.T) {
 		t.Parallel()
 
+		codec := zbor.NewCodec()
+		l := &Library{
+			codec: codec,
+		}
+
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
-
-		codec := zbor.NewCodec()
-		l := &Library{codec}
 
 		for i := 0; i < entries; i++ {
 			height := mocks.GenericHeight + uint64(i)
@@ -1296,11 +1293,13 @@ func TestLibrary_IterateLedger(t *testing.T) {
 	t.Run("handles multiple payloads with the same path", func(t *testing.T) {
 		t.Parallel()
 
+		codec := zbor.NewCodec()
+		l := &Library{
+			codec: codec,
+		}
+
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
-
-		codec := zbor.NewCodec()
-		l := &Library{codec}
 
 		// Always use paths[0] for every payload.
 		path := paths[0]
@@ -1327,11 +1326,13 @@ func TestLibrary_IterateLedger(t *testing.T) {
 	t.Run("handles exclusion of payloads below specified height", func(t *testing.T) {
 		t.Parallel()
 
+		codec := zbor.NewCodec()
+		l := &Library{
+			codec: codec,
+		}
+
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
-
-		codec := zbor.NewCodec()
-		l := &Library{codec}
 
 		for i := 0; i < entries; i++ {
 			height := mocks.GenericHeight + uint64(i)
@@ -1355,14 +1356,16 @@ func TestLibrary_IterateLedger(t *testing.T) {
 	t.Run("handles codec failure", func(t *testing.T) {
 		t.Parallel()
 
-		db := helpers.InMemoryDB(t)
-		defer db.Close()
-
 		codec := mocks.BaselineCodec(t)
 		codec.UnmarshalFunc = func([]byte, interface{}) error {
 			return mocks.GenericError
 		}
-		l := &Library{codec}
+		l := &Library{
+			codec: codec,
+		}
+
+		db := helpers.InMemoryDB(t)
+		defer db.Close()
 
 		for i := 0; i < entries; i++ {
 			height := mocks.GenericHeight + uint64(i)
@@ -1385,11 +1388,13 @@ func TestLibrary_IterateLedger(t *testing.T) {
 	t.Run("handles callback error", func(t *testing.T) {
 		t.Parallel()
 
+		codec := zbor.NewCodec()
+		l := &Library{
+			codec: codec,
+		}
+
 		db := helpers.InMemoryDB(t)
 		defer db.Close()
-
-		codec := zbor.NewCodec()
-		l := &Library{codec}
 
 		for i := 0; i < entries; i++ {
 			height := mocks.GenericHeight + uint64(i)

--- a/service/storage/operations_internal_test.go
+++ b/service/storage/operations_internal_test.go
@@ -919,6 +919,7 @@ func TestSaveAndRetrieve_Collection(t *testing.T) {
 
 	t.Run("save collection", func(t *testing.T) {
 		t.Parallel()
+
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, &flow.LightCollection{}, v)
@@ -976,6 +977,7 @@ func TestSaveAndRetrieve_Guarantee(t *testing.T) {
 
 	t.Run("save guarantee", func(t *testing.T) {
 		t.Parallel()
+
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, &flow.CollectionGuarantee{}, v)
@@ -1033,6 +1035,7 @@ func TestIndexAndLookup_CollectionsForHeight(t *testing.T) {
 
 	t.Run("save collections", func(t *testing.T) {
 		t.Parallel()
+
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, []flow.Identifier{}, v)
@@ -1089,6 +1092,7 @@ func TestSaveAndRetrieve_TransactionResults(t *testing.T) {
 
 	t.Run("save transaction result", func(t *testing.T) {
 		t.Parallel()
+
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, &flow.TransactionResult{}, v)
@@ -1146,6 +1150,7 @@ func TestSaveAndRetrieve_Seal(t *testing.T) {
 
 	t.Run("save seal", func(t *testing.T) {
 		t.Parallel()
+
 		codec := mocks.BaselineCodec(t)
 		codec.MarshalFunc = func(v interface{}) ([]byte, error) {
 			assert.IsType(t, &flow.Seal{}, v)

--- a/service/storage/operations_internal_test.go
+++ b/service/storage/operations_internal_test.go
@@ -1348,8 +1348,8 @@ func TestLibrary_IterateLedger(t *testing.T) {
 
 		err := db.View(op)
 
-		assert.NoError(t, err)
-		assert.Len(t, got, 0)
+		require.NoError(t, err)
+		assert.Empty(t, got)
 	})
 
 	t.Run("handles codec failure", func(t *testing.T) {

--- a/service/tracker/execution_internal_test.go
+++ b/service/tracker/execution_internal_test.go
@@ -59,8 +59,6 @@ func TestNewExecution(t *testing.T) {
 		stream := mocks.BaselineRecordStreamer(t)
 
 		db := helpers.InMemoryDB(t)
-		// Do not insert root height.
-		//require.NoError(t, db.Update(operation.InsertRootHeight(header.Height)))
 		require.NoError(t, db.Update(operation.IndexBlockHeight(header.Height, blockID)))
 		require.NoError(t, db.Update(operation.InsertHeader(blockID, header)))
 		require.NoError(t, db.Update(operation.IndexBlockSeal(blockID, seal.ID())))
@@ -77,8 +75,6 @@ func TestNewExecution(t *testing.T) {
 
 		db := helpers.InMemoryDB(t)
 		require.NoError(t, db.Update(operation.InsertRootHeight(header.Height)))
-		// Do not insert block height.
-		//require.NoError(t, db.Update(operation.IndexBlockHeight(header.Height, blockID)))
 		require.NoError(t, db.Update(operation.InsertHeader(blockID, header)))
 		require.NoError(t, db.Update(operation.IndexBlockSeal(blockID, seal.ID())))
 		require.NoError(t, db.Update(operation.InsertSeal(seal.ID(), seal)))
@@ -95,8 +91,6 @@ func TestNewExecution(t *testing.T) {
 		db := helpers.InMemoryDB(t)
 		require.NoError(t, db.Update(operation.InsertRootHeight(header.Height)))
 		require.NoError(t, db.Update(operation.IndexBlockHeight(header.Height, blockID)))
-		// Do not insert header.
-		//require.NoError(t, db.Update(operation.InsertHeader(blockID, header)))
 		require.NoError(t, db.Update(operation.IndexBlockSeal(blockID, seal.ID())))
 		require.NoError(t, db.Update(operation.InsertSeal(seal.ID(), seal)))
 
@@ -113,8 +107,6 @@ func TestNewExecution(t *testing.T) {
 		require.NoError(t, db.Update(operation.InsertRootHeight(header.Height)))
 		require.NoError(t, db.Update(operation.IndexBlockHeight(header.Height, blockID)))
 		require.NoError(t, db.Update(operation.InsertHeader(blockID, header)))
-		// Do not insert seal ID.
-		//require.NoError(t, db.Update(operation.IndexBlockSeal(blockID, seal.ID())))
 		require.NoError(t, db.Update(operation.InsertSeal(seal.ID(), seal)))
 
 		_, err := NewExecution(log, db, stream)
@@ -131,8 +123,6 @@ func TestNewExecution(t *testing.T) {
 		require.NoError(t, db.Update(operation.IndexBlockHeight(header.Height, blockID)))
 		require.NoError(t, db.Update(operation.InsertHeader(blockID, header)))
 		require.NoError(t, db.Update(operation.IndexBlockSeal(blockID, seal.ID())))
-		// Do not insert seal.
-		//require.NoError(t, db.Update(operation.InsertSeal(seal.ID(), seal)))
 
 		_, err := NewExecution(log, db, stream)
 


### PR DESCRIPTION
## Goal of this PR

This PR adds tests for the updated `IterateLedger` function - testing exclusion of payloads below a certain height.

## Checklist

- [x] Is on the right branch
- [ ] ~Documentation is up-to-date~
- [x] Tests are up-to-date
