### PR TITLE
Expose badger and go metrics

### DIFF
--- a/cmd/flow-dps-indexer/README.md
+++ b/cmd/flow-dps-indexer/README.md
@@ -15,7 +15,7 @@ Usage of flow-dps-indexer:
   -f, --force               force indexing to bootstrap from root checkpoint and overwrite existing index
   -i, --index string        path to database directory for state index (default "index")
   -l, --level string        log output level (default "info")
-  -m, --metrics string      URL on which to expose metrics (no metrics are exposed when left empty)
+  -m, --metrics string      address on which to expose metrics (no metrics are exposed when left empty)
   -s, --skip                skip indexing of execution state ledger registers
   -t, --trie string         path to data directory for execution state ledger
 ```

--- a/cmd/flow-dps-indexer/README.md
+++ b/cmd/flow-dps-indexer/README.md
@@ -15,7 +15,6 @@ Usage of flow-dps-indexer:
   -f, --force               force indexing to bootstrap from root checkpoint and overwrite existing index
   -i, --index string        path to database directory for state index (default "index")
   -l, --level string        log output level (default "info")
-  -m, --metrics string      address on which to expose metrics (no metrics are exposed when left empty)
   -s, --skip                skip indexing of execution state ledger registers
   -t, --trie string         path to data directory for execution state ledger
 ```

--- a/cmd/flow-dps-indexer/README.md
+++ b/cmd/flow-dps-indexer/README.md
@@ -15,6 +15,7 @@ Usage of flow-dps-indexer:
   -f, --force               force indexing to bootstrap from root checkpoint and overwrite existing index
   -i, --index string        path to database directory for state index (default "index")
   -l, --level string        log output level (default "info")
+  -m, --metrics string      URL on which to expose metrics (no metrics are exposed when left empty)
   -s, --skip                skip indexing of execution state ledger registers
   -t, --trie string         path to data directory for execution state ledger
 ```

--- a/cmd/flow-dps-indexer/main.go
+++ b/cmd/flow-dps-indexer/main.go
@@ -71,7 +71,7 @@ func run() int {
 	pflag.BoolVarP(&flagForce, "force", "f", false, "force indexing to bootstrap from root checkpoint and overwrite existing index")
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "path to database directory for state index")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
-	pflag.StringVarP(&flagMetrics, "metrics", "m", "", "URL on which to expose metrics (no metrics are exposed when left empty)")
+	pflag.StringVarP(&flagMetrics, "metrics", "m", "", "address on which to expose metrics (no metrics are exposed when left empty)")
 	pflag.StringVarP(&flagTrie, "trie", "t", "", "path to data directory for execution state ledger")
 	pflag.BoolVarP(&flagSkip, "skip", "s", false, "skip indexing of execution state ledger registers")
 

--- a/cmd/flow-dps-indexer/main.go
+++ b/cmd/flow-dps-indexer/main.go
@@ -16,12 +16,14 @@ package main
 
 import (
 	"errors"
+	"net/http"
 	"os"
 	"os/signal"
 	"runtime"
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
+	_ "github.com/dgraph-io/badger/v2/y"
 	"github.com/prometheus/tsdb/wal"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
@@ -59,6 +61,7 @@ func run() int {
 		flagForce      bool
 		flagIndex      string
 		flagLevel      string
+		flagMetrics      string
 		flagTrie       string
 		flagSkip       bool
 	)
@@ -68,6 +71,7 @@ func run() int {
 	pflag.BoolVarP(&flagForce, "force", "f", false, "force indexing to bootstrap from root checkpoint and overwrite existing index")
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "path to database directory for state index")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
+	pflag.StringVarP(&flagMetrics, "metrics", "m", "", "URL on which to expose metrics (no metrics are exposed when left empty)")
 	pflag.StringVarP(&flagTrie, "trie", "t", "", "path to data directory for execution state ledger")
 	pflag.BoolVarP(&flagSkip, "skip", "s", false, "skip indexing of execution state ledger registers")
 
@@ -110,6 +114,7 @@ func run() int {
 			log.Error().Err(err).Msg("could not close protocol state database")
 		}
 	}()
+
 	// The storage library is initialized with a codec and provides functions to
 	// interact with a Badger database while encoding and compressing
 	// transparently.
@@ -204,6 +209,26 @@ func run() int {
 		finish := time.Now()
 		duration := finish.Sub(start)
 		log.Info().Time("finish", finish).Str("duration", duration.Round(time.Second).String()).Msg("Flow DPS Indexer stopped")
+	}()
+
+	// Expose badgerDB and go metrics.
+	go func() {
+		if flagMetrics == "" {
+			return
+		}
+
+		start := time.Now()
+		log.Info().Time("start", start).Msg("Metrics server starting")
+		err := http.ListenAndServe(":8080", nil)
+		if err != nil {
+			log.Warn().Err(err).Msg("Metrics server failed")
+			close(failed)
+		} else {
+			close(done)
+		}
+		finish := time.Now()
+		duration := finish.Sub(start)
+		log.Info().Time("finish", finish).Str("duration", duration.Round(time.Second).String()).Msg("Metrics server stopped")
 	}()
 
 	select {

--- a/cmd/flow-dps-indexer/main.go
+++ b/cmd/flow-dps-indexer/main.go
@@ -61,7 +61,7 @@ func run() int {
 		flagForce      bool
 		flagIndex      string
 		flagLevel      string
-		flagMetrics      string
+		flagMetrics    string
 		flagTrie       string
 		flagSkip       bool
 	)

--- a/cmd/flow-dps-live/README.md
+++ b/cmd/flow-dps-live/README.md
@@ -18,7 +18,7 @@ Usage of flow-dps-live:
   -f, --force                     force indexing to bootstrap from root checkpoint and overwrite existing index
   -i, --index string              path to database directory for state index (default "index")
   -l, --level string              log output level (default "info")
-  -m, --metrics string            URL on which to expose metrics (no metrics are exposed when left empty)
+  -m, --metrics string            address on which to expose metrics (no metrics are exposed when left empty)
   -s, --skip                      skip indexing of execution state ledger registers
       --flush-interval duration   interval for flushing badger transactions (0s for disabled)
       --seed-address string       host address of seed node to follow consensus

--- a/cmd/flow-dps-live/README.md
+++ b/cmd/flow-dps-live/README.md
@@ -18,6 +18,7 @@ Usage of flow-dps-live:
   -f, --force                     force indexing to bootstrap from root checkpoint and overwrite existing index
   -i, --index string              path to database directory for state index (default "index")
   -l, --level string              log output level (default "info")
+  -m, --metrics string            URL on which to expose metrics (no metrics are exposed when left empty)
   -s, --skip                      skip indexing of execution state ledger registers
       --flush-interval duration   interval for flushing badger transactions (0s for disabled)
       --seed-address string       host address of seed node to follow consensus

--- a/cmd/flow-dps-live/main.go
+++ b/cmd/flow-dps-live/main.go
@@ -98,7 +98,7 @@ func run() int {
 	pflag.BoolVarP(&flagForce, "force", "f", false, "force indexing to bootstrap from root checkpoint and overwrite existing index")
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "path to database directory for state index")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
-	pflag.StringVarP(&flagMetrics, "metrics", "m", "", "URL on which to expose metrics (no metrics are exposed when left empty)")
+	pflag.StringVarP(&flagMetrics, "metrics", "m", "", "address on which to expose metrics (no metrics are exposed when left empty)")
 	pflag.BoolVarP(&flagSkip, "skip", "s", false, "skip indexing of execution state ledger registers")
 
 	pflag.DurationVar(&flagFlushInterval, "flush-interval", 1*time.Second, "interval for flushing badger transactions (0s for disabled)")
@@ -409,17 +409,17 @@ func run() int {
 		}
 
 		start := time.Now()
-		log.Info().Time("start", start).Msg("Metrics server starting")
+		log.Info().Time("start", start).Msg("metrics server starting")
 		err := http.ListenAndServe(flagMetrics, nil)
 		if err != nil {
-			log.Warn().Err(err).Msg("Metrics server failed")
+			log.Warn().Err(err).Msg("metrics server failed")
 			close(failed)
 		} else {
 			close(done)
 		}
 		finish := time.Now()
 		duration := finish.Sub(start)
-		log.Info().Time("finish", finish).Str("duration", duration.Round(time.Second).String()).Msg("Metrics server stopped")
+		log.Info().Time("finish", finish).Str("duration", duration.Round(time.Second).String()).Msg("metrics server stopped")
 	}()
 
 	// Here, we are waiting for a signal, or for one of the components to fail

--- a/cmd/flow-dps-live/main.go
+++ b/cmd/flow-dps-live/main.go
@@ -29,6 +29,7 @@ import (
 
 	gcloud "cloud.google.com/go/storage"
 	"github.com/dgraph-io/badger/v2"
+	_ "github.com/dgraph-io/badger/v2/y"
 	grpczerolog "github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/tags"
@@ -81,6 +82,7 @@ func run() int {
 		flagForce      bool
 		flagIndex      string
 		flagLevel      string
+		flagMetrics      string
 		flagSkip       bool
 
 		flagFlushInterval time.Duration
@@ -96,6 +98,7 @@ func run() int {
 	pflag.BoolVarP(&flagForce, "force", "f", false, "force indexing to bootstrap from root checkpoint and overwrite existing index")
 	pflag.StringVarP(&flagIndex, "index", "i", "index", "path to database directory for state index")
 	pflag.StringVarP(&flagLevel, "level", "l", "info", "log output level")
+	pflag.StringVarP(&flagMetrics, "metrics", "m", "", "URL on which to expose metrics (no metrics are exposed when left empty)")
 	pflag.BoolVarP(&flagSkip, "skip", "s", false, "skip indexing of execution state ledger registers")
 
 	pflag.DurationVar(&flagFlushInterval, "flush-interval", 1*time.Second, "interval for flushing badger transactions (0s for disabled)")
@@ -397,6 +400,26 @@ func run() int {
 			log.Warn().Err(err).Msg("Flow DPS Server failed")
 		}
 		log.Info().Msg("Flow DPS Live Server stopped")
+	}()
+
+	// Expose badgerDB and go metrics.
+	go func() {
+		if flagMetrics == "" {
+			return
+		}
+
+		start := time.Now()
+		log.Info().Time("start", start).Msg("Metrics server starting")
+		err := http.ListenAndServe(flagMetrics, nil)
+		if err != nil {
+			log.Warn().Err(err).Msg("Metrics server failed")
+			close(failed)
+		} else {
+			close(done)
+		}
+		finish := time.Now()
+		duration := finish.Sub(start)
+		log.Info().Time("finish", finish).Str("duration", duration.Round(time.Second).String()).Msg("Metrics server stopped")
 	}()
 
 	// Here, we are waiting for a signal, or for one of the components to fail

--- a/cmd/flow-dps-live/main.go
+++ b/cmd/flow-dps-live/main.go
@@ -82,7 +82,7 @@ func run() int {
 		flagForce      bool
 		flagIndex      string
 		flagLevel      string
-		flagMetrics      string
+		flagMetrics    string
 		flagSkip       bool
 
 		flagFlushInterval time.Duration


### PR DESCRIPTION
## Goal of this PR

Fixes #488 

This PR imports `"github.com/dgraph-io/badger/v2/y"` in both indexer binaries, so that the metrics are exposed on the default HTTP handler. It also adds an HTTP server to both binaries which exposes the default handler (which is why it's given a `nil` handler).

You can test this PR by running the indexer and making a `curl` call to `<FLAG_METRICS>/debug/vars`, depending on what you set as the `--metrics` parameter.

FYI, here is the `init` function in badger's metrics package:

```go
func init() {
  http.HandleFunc("/debug/vars", expvarHandler)
  Publish("cmdline", Func(cmdline))
  Publish("memstats", Func(memstats))
}
```

The exposed metrics are expvar metrics, so in order to consume them with something like prometheus, you will need external tooling, such as [prometheus-expvar-exporter](https://github.com/albertito/prometheus-expvar-exporter).

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date