### PR TITLE
Make metrics server listen on the correct address

### DIFF
--- a/cmd/flow-dps-live/main.go
+++ b/cmd/flow-dps-live/main.go
@@ -171,7 +171,6 @@ func run() int {
 	// fill up fast enough. This avoids having latency between when we add data
 	// to the transaction and when it becomes available on-disk for serving the
 	// DPS API.
-	metricsEnabled := flagMetrics != ""
 	write := index.NewWriter(
 		indexDB,
 		storage,
@@ -344,6 +343,7 @@ func run() int {
 	// If metrics are enabled, the mapper should use the metrics writer. Otherwise, it can
 	// use the regular one.
 	writer := dps.Writer(write)
+	metricsEnabled := flagMetrics != ""
 	if metricsEnabled {
 		writer = index.NewMetricsWriter(write)
 	}
@@ -429,7 +429,7 @@ func run() int {
 		}
 
 		log.Info().Msg("metrics server starting")
-		server := metrics.NewServer(log, flagAddress)
+		server := metrics.NewServer(log, flagMetrics)
 		err := server.Start()
 		if err != nil {
 			log.Warn().Err(err).Msg("metrics server failed")

--- a/service/index/metrics.go
+++ b/service/index/metrics.go
@@ -39,37 +39,37 @@ type MetricsWriter struct {
 func NewMetricsWriter(write *Writer) *MetricsWriter {
 	blockOpts := prometheus.CounterOpts{
 		Name: "indexed_blocks",
-		Help: "the number of indexed blocks",
+		Help: "number of indexed blocks",
 	}
 	block := promauto.NewCounter(blockOpts)
 
 	registerOpts := prometheus.CounterOpts{
 		Name: "indexed_registers",
-		Help: "the number of indexed registers",
+		Help: "number of indexed registers",
 	}
 	register := promauto.NewCounter(registerOpts)
 
 	collectionOpts := prometheus.CounterOpts{
 		Name: "indexed_collections",
-		Help: "the number of indexed collections",
+		Help: "number of indexed collections",
 	}
 	collection := promauto.NewCounter(collectionOpts)
 
 	transactionsOpts := prometheus.CounterOpts{
 		Name: "indexed_transactions",
-		Help: "the number of indexed transactions",
+		Help: "number of indexed transactions",
 	}
 	transaction := promauto.NewCounter(transactionsOpts)
 
 	eventOpts := prometheus.CounterOpts{
 		Name: "indexed_events",
-		Help: "the number of indexed events",
+		Help: "number of indexed events",
 	}
 	event := promauto.NewCounter(eventOpts)
 
 	sealOpts := prometheus.CounterOpts{
 		Name: "indexed_seals",
-		Help: "the number of indexed seals",
+		Help: "number of indexed seals",
 	}
 	seal := promauto.NewCounter(sealOpts)
 

--- a/service/metrics/server.go
+++ b/service/metrics/server.go
@@ -15,6 +15,7 @@
 package metrics
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -48,12 +49,12 @@ func NewServer(log zerolog.Logger, address string) *Server {
 func (s *Server) Start() error {
 	err := RegisterBadgerMetrics()
 	if err != nil {
-		return err
+		return fmt.Errorf("could not register badger metrics: %w", err)
 	}
 
 	err = s.server.ListenAndServe()
 	if err != nil {
-		return err
+		return fmt.Errorf("could not listen and serve: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Goal of this PR

Fixes some issues from the previously merged PR, #492, that @Maelkum reported but right after the PR was merged.

Since one of them is absolutely critical (the metrics listening on the wrong address), this needs to be reviewed with high priority and a new release needs to be drafted, as the current release might even crash because of this bug.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date