### PR TITLE
Make past spork indexer handle bootstrapping like live indexer

### DIFF
--- a/cmd/flow-dps-indexer/README.md
+++ b/cmd/flow-dps-indexer/README.md
@@ -12,7 +12,6 @@ The index is generated in the form of a Badger database that allows random acces
 Usage of flow-dps-indexer:
   -c, --checkpoint string   path to root checkpoint file for execution state trie
   -d, --data string         path to database directory for protocol data (default "data")
-  -f, --force               force indexing to bootstrap from root checkpoint and overwrite existing index
   -i, --index string        path to database directory for state index (default "index")
   -l, --level string        log output level (default "info")
   -s, --skip                skip indexing of execution state ledger registers

--- a/cmd/flow-dps-live/main.go
+++ b/cmd/flow-dps-live/main.go
@@ -316,6 +316,7 @@ func run() int {
 	// checkpoint; if we don't, we can optionally use the root checkpoint to
 	// speed up the restart/restoration.
 	var load mapper.Loader
+	load = loader.FromIndex(log, storage, indexDB)
 	if empty {
 		file, err := os.Open(flagCheckpoint)
 		if err != nil {
@@ -331,13 +332,11 @@ func run() int {
 			return failure
 		}
 		defer file.Close()
-		load = loader.FromCheckpoint(file)
+		initialize := loader.FromCheckpoint(file)
 		load = loader.FromIndex(log, storage, indexDB,
-			loader.WithInitializer(load),
+			loader.WithInitializer(initialize),
 			loader.WithExclude(loader.ExcludeAtOrBelow(first)),
 		)
-	} else {
-		load = loader.FromIndex(log, storage, indexDB)
 	}
 
 	// If metrics are enabled, the mapper should use the metrics writer. Otherwise, it can


### PR DESCRIPTION
## Goal of this PR

Fixes #499 

Makes the past spork indexer behave like the live spork indexer when it comes to bootstrapping:

* If an index already exists but we can't read from it, fail
* If the index is empty and no checkpoint is given, fail
* If the index is empty, load the given checkpoint
* If the index is not empty and that a checkpoint is given, use the checkpoint to initialize the loader and then load from the index
* If the index is not empty and that no checkpoint is given, start from the index

Doing things this way makes the `--force` option not needed anymore, since we can now combine having an index and a checkpoint at the same time.

## Checklist

- [x] Is on the right branch
- [x] Documentation is up-to-date
- [x] Tests are up-to-date